### PR TITLE
ZEN-24758 WIP: turn pagespeed off to unblock QA

### DIFF
--- a/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.saas/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.saas/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/nfvi/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/nfvi/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/ucspm.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/ucspm.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/ucspm/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/ucspm/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/testdata/model/Zenoss.core.fake/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/testdata/model/Zenoss.core.fake/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,7 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed on;
+        pagespeed off;
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;


### PR DESCRIPTION
The pagespeed nginx plugin is involved in the serving of unsafe scripts which causes the RM UI to not render.