### PR TITLE
ZEN-21938 Remove uintToInt method

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.core.full/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
@@ -10,11 +10,7 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
+innodb_buffer_pool_instances = 3 
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/Zenoss.core/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.core/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
@@ -10,11 +10,7 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
+innodb_buffer_pool_instances = 3 
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -10,11 +10,7 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
+innodb_buffer_pool_instances = 3 
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}}  
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/Zenoss.resmgr/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.resmgr/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -10,11 +10,7 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
+innodb_buffer_pool_instances = 3 
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/Zenoss.saas/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.saas/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -10,11 +10,7 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
+innodb_buffer_pool_instances = 3 
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}}  
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/ucspm.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/ucspm.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -10,11 +10,7 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
+innodb_buffer_pool_instances = 3
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}}  
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/ucspm/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/ucspm/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -10,12 +10,8 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
-innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}}  
+innodb_buffer_pool_instances = 3 
+innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be
 # easily adjusted after image creation time.

--- a/testdata/model/Zenoss.core.fake/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
+++ b/testdata/model/Zenoss.core.fake/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
@@ -10,11 +10,7 @@ log_error=/var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 
-{{with $coresless1 := plus (uintToInt .CPUCommitment) -1 }}  
-innodb_buffer_pool_instances = {{$coresless1}} 
-{{else}} 
-innodb_buffer_pool_instances = 1 
-{{end}} 
+innodb_buffer_pool_instances = 3 
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be


### PR DESCRIPTION
Remove the uintToInt method to provide backward compatibility. The default for mariadb-model and mariadb-events is now 3 which is the default CPU Commitment 4 minus 1.