### PR TITLE
Fix ZEN-24758: exclude i18n.js from pagespeed bundling

### DIFF
--- a/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.saas/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.saas/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/nfvi/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/nfvi/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/ucspm.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/ucspm.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/ucspm/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/ucspm/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/testdata/model/Zenoss.core.fake/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/testdata/model/Zenoss.core.fake/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -59,7 +59,8 @@ http {
         listen 8080;
         set $myhost $http_host;
 
-        pagespeed off;
+        pagespeed on;
+        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;


### PR DESCRIPTION
Fixes broken RM UI rendering, which is caused seemingly by a request for i18n.js over HTTP creating a mixed content request, which is blocked by the browser. Adding a `Disallow *i18n*` to nginx.conf prevents insecure request for i18n.js from being bundled.

To test within an active deployment 

  1. `serviced service attach Zenoss.core` or `serviced service attach Zenoss.resmgr[.lite]`
  2. edit `/opt/zenoss/zproxy/conf/nginx.conf`
  3. change the line `pagespeed off;` to `pagespeed on;`
  4. and add the following line  `pagespeed Disallow '*i18n*';`
  5. restart nginx `LD_LIBRARY_PATH=/opt/zenoss/zproxy/lib/ /opt/zenoss/zproxy/sbin/nginx -s reload`
  6. Open the RM UI and bring up web developer tools. Load the Dashboard or Infrastructure page within the resmgr UI. Reload at least three times to ensure pagespeed is bundling asset requests. Check the network request for blocked or 404 requests because of the mixed content after each load.
  