### PR TITLE
Remove i18n.js exclusion in pagespeed bundles in light of CC-2679 fix

### DIFF
--- a/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/Zenoss.saas/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.saas/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/nfvi/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/nfvi/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/ucspm.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/ucspm.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/services/ucspm/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/ucspm/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;

--- a/testdata/model/Zenoss.core.fake/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/testdata/model/Zenoss.core.fake/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -60,7 +60,6 @@ http {
         set $myhost $http_host;
 
         pagespeed on;
-        pagespeed Disallow '*i18n*';
         pagespeed RewriteLevel CoreFilters;
         pagespeed FileCachePath /opt/zenoss/var/zproxy/ngx_pagespeed_cache;
         pagespeed UseExperimentalJsMinifier on;


### PR DESCRIPTION
The exclusion of i18n.js is no longer needed to prevent nginx from serving mixed content bundles when pagespeed is enabled, now that `serviced/web/vhost.go` sets the X-Forwarded-Proto as https.