### PR TITLE
Add existence of HBase tables to OpenTSDB reader prereqs

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
@@ -65,6 +65,10 @@
         {
             "Name": "HBase Regionservers up",
             "Script": "{{with $rss := (child (child (parent (parent .)) \"HBase\") \"RegionServer\").Instances }}wget -q -O- http://localhost:61000/status/cluster | grep '{{$rss}} live servers'{{end}}"
+        },
+        {
+            "Name": "HBase tables exist",
+            "Script": "wget -q -O- http://localhost:61000 | [[ $(grep -c -E -o \"\\b${CONTROLPLANE_TENANT_ID}-tsdb(-|\\s|$)\") == 4 ]]"
         }
     ],
     "RAMCommitment": "1G",

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
@@ -65,6 +65,10 @@
         {
             "Name": "HBase Regionservers up",
             "Script": "{{with $rss := (child (child (parent (parent .)) \"HBase\") \"RegionServer\").Instances }}wget -q -O- http://localhost:61000/status/cluster | grep '{{$rss}} live servers'{{end}}"
+        },
+        {
+            "Name": "HBase tables exist",
+            "Script": "wget -q -O- http://localhost:61000 | [[ $(grep -c -E -o \"\\b${CONTROLPLANE_TENANT_ID}-tsdb(-|\\s|$)\") == 4 ]]"
         }
     ],
     "RAMCommitment": "1G",

--- a/services/Zenoss.saas/opentsdb/reader/service.json
+++ b/services/Zenoss.saas/opentsdb/reader/service.json
@@ -65,6 +65,10 @@
         {
             "Name": "HBase Regionservers up",
             "Script": "{{with $rss := (child (child (parent (parent .)) \"HBase\") \"RegionServer\").Instances }}wget -q -O- http://localhost:61000/status/cluster | grep '{{$rss}} live servers'{{end}}"
+        },
+        {
+            "Name": "HBase tables exist",
+            "Script": "wget -q -O- http://localhost:61000 | [[ $(grep -c -E -o \"\\b${CONTROLPLANE_TENANT_ID}-tsdb(-|\\s|$)\") == 4 ]]"
         }
     ],
     "RAMCommitment": "1G",

--- a/services/nfvi/Infrastructure/opentsdb/reader/service.json
+++ b/services/nfvi/Infrastructure/opentsdb/reader/service.json
@@ -65,6 +65,10 @@
         {
             "Name": "HBase Regionservers up",
             "Script": "{{with $rss := (child (child (parent (parent .)) \"HBase\") \"RegionServer\").Instances }}wget -q -O- http://localhost:61000/status/cluster | grep '{{$rss}} live servers'{{end}}"
+        },
+        {
+            "Name": "HBase tables exist",
+            "Script": "wget -q -O- http://localhost:61000 | [[ $(grep -c -E -o \"\\b${CONTROLPLANE_TENANT_ID}-tsdb(-|\\s|$)\") == 4 ]]"
         }
     ],
     "RAMCommitment": "1G",

--- a/services/ucspm/Infrastructure/opentsdb/reader/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/reader/service.json
@@ -65,6 +65,10 @@
         {
             "Name": "HBase Regionservers up",
             "Script": "{{with $rss := (child (child (parent (parent .)) \"HBase\") \"RegionServer\").Instances }}wget -q -O- http://localhost:61000/status/cluster | grep '{{$rss}} live servers'{{end}}"
+        },
+        {
+            "Name": "HBase tables exist",
+            "Script": "wget -q -O- http://localhost:61000 | [[ $(grep -c -E -o \"\\b${CONTROLPLANE_TENANT_ID}-tsdb(-|\\s|$)\") == 4 ]]"
         }
     ],
     "RAMCommitment": "1G",


### PR DESCRIPTION
A reader service checks if the necessary HBase tables have been created by a writer instance.
The migration script for this change has been already merged. See https://github.com/zenoss/zenoss-prodbin/pull/1886.