### PR TITLE
Change the metrics reporting period of hbase services to 15 secs

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.saas/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.saas/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/Zenoss.saas/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.saas/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/nfvi/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/nfvi/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/nfvi/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/nfvi/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/ucspm/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.

--- a/services/ucspm/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -18,7 +18,7 @@
 # See javadoc of package-info.java for org.apache.hadoop.metrics2 for details
 
 # sampling period
-*.period=1
+*.period=15
 
 # Below are some examples of sinks that could be used
 # to monitor different hbase daemons.


### PR DESCRIPTION
Set the sampling period in the Hadoop Metrics 2 config to 15 secs. The migration script for this change has been already merged. See https://github.com/zenoss/zenoss-prodbin/pull/1890.