### PR TITLE
ZEN-25579: add metric config for new graph

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",

--- a/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",

--- a/services/Zenoss.saas/HBase/HMaster/service.json
+++ b/services/Zenoss.saas/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/Zenoss.saas/HBase/RegionServer/service.json
+++ b/services/Zenoss.saas/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",

--- a/services/nfvi/Infrastructure/HBase/HMaster/service.json
+++ b/services/nfvi/Infrastructure/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/nfvi/Infrastructure/HBase/RegionServer/service.json
+++ b/services/nfvi/Infrastructure/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",

--- a/services/ucspm/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm/Infrastructure/HBase/HMaster/service.json
@@ -189,6 +189,35 @@
                 "type": "line",
                 "yAxisLabel": "servers"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "HMaster internal metrics",
+                "ID": "HMaster",
+                "Metrics": [
+                    {
+                        "ID": "LogFatal",
+                        "Name": "Total number of fatal log events"
+                    },
+                    {
+                        "ID": "LogError",
+                        "Name": "Total number of error log events"
+                    },
+                    {
+                        "ID": "LogWarn",
+                        "Name": "Total number of warn log events"
+                    },
+                    {
+                        "ID": "numRegionServers",
+                        "Name": "Total number of live regions servers"
+                    },
+                    {
+                        "ID": "numDeadRegionServers",
+                        "Name": "Total number of dead regions servers"
+                    }
+                ],
+                "Name": "HMaster internal metrics"
+            }
         ]
     },
     "Name": "HMaster",

--- a/services/ucspm/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/service.json
@@ -255,6 +255,59 @@
                 "type": "line",
                 "yAxisLabel": "Operations"
             }
+        ],
+        "MetricConfigs": [
+            {
+                "Description": "RegionServer internal metrics",
+                "ID": "RegionServer",
+                "Metrics": [
+                    {
+                        "ID": "numCallsInGeneralQueue",
+                        "Name": "Current depth of the User Requests"
+                    },
+                    {
+                        "ID": "numCallsInPriorityQueue",
+                        "Name": "Current depth of the Internal Housekeeping Requests queue"
+                    },
+                    {
+                        "ID": "flushQueueLength",
+                        "Name": "Current depth of the memstore flush queue"
+                    },
+                    {
+                        "ID": "compactionQueueLength",
+                        "Name": "Current depth of the compaction request queue"
+                    },
+                    {
+                        "ID": "slowAppendCount",
+                        "Name": "The number of slow append operations"
+                    },
+                    {
+                        "ID": "slowDeleteCount",
+                        "Name": "The number of slow delete operations"
+                    },
+                    {
+                        "ID": "slowGetCount",
+                        "Name": "The number of slow get operations"
+                    },
+                    {
+                        "ID": "slowIncrementCount",
+                        "Name": "The number of slow increment operations"
+                    },
+                    {
+                        "ID": "totalRequestCount",
+                        "Name": "The total number of requests received"
+                    },
+                    {
+                        "ID": "readRequestCount",
+                        "Name": "The total number of read requests received"
+                    },
+                    {
+                        "ID": "writeRequestCount",
+                        "Name": "The total number of write requests received"
+                    }
+                ],
+                "Name": "RegionServer internal metrics"
+            }
         ]
     },
     "Name": "RegionServer",


### PR DESCRIPTION
There was no data-points when monitoring CC from RM,
therefore respective graphs wasn't displaying data.

Add new metric config for data-points of the new graphs.