### PR TITLE
ZEN-25579: add metric source to graph datapoints, change datapoints name

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }

--- a/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }

--- a/services/Zenoss.saas/HBase/HMaster/service.json
+++ b/services/Zenoss.saas/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/Zenoss.saas/HBase/RegionServer/service.json
+++ b/services/Zenoss.saas/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }

--- a/services/nfvi/Infrastructure/HBase/HMaster/service.json
+++ b/services/nfvi/Infrastructure/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/nfvi/Infrastructure/HBase/RegionServer/service.json
+++ b/services/nfvi/Infrastructure/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }

--- a/services/ucspm/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm/Infrastructure/HBase/HMaster/service.json
@@ -90,7 +90,8 @@
                         "id": "LogFatal",
                         "legend": "Total number of fatal log events",
                         "metric": "LogFatal",
-                        "name": "LogFatal",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of fatal log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -105,7 +106,8 @@
                         "id": "LogError",
                         "legend": "Total number of error log events",
                         "metric": "LogError",
-                        "name": "LogError",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of error log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -120,7 +122,8 @@
                         "id": "LogWarn",
                         "legend": "Total number of warn log events",
                         "metric": "LogWarn",
-                        "name": "LogWarn",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of warn log events",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -151,7 +154,8 @@
                         "id": "numRegionServers",
                         "legend": "Total number of live regions servers",
                         "metric": "numRegionServers",
-                        "name": "numRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of live regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -166,7 +170,8 @@
                         "id": "numDeadRegionServers",
                         "legend": "Total number of dead regions servers",
                         "metric": "numDeadRegionServers",
-                        "name": "numDeadRegionServers",
+                        "metricSource": "Hmaster",
+                        "name": "Total number of dead regions servers",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,

--- a/services/ucspm/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/service.json
@@ -85,7 +85,8 @@
                         "id": "numCallsInGeneralQueue",
                         "legend": "Current depth of the User Requests",
                         "metric": "numCallsInGeneralQueue",
-                        "name": "numCallsInGeneralQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the User Requests",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -100,7 +101,8 @@
                         "id": "numCallsInPriorityQueue",
                         "legend": "Current depth of the Internal Housekeeping Requests queue",
                         "metric": "numCallsInPriorityQueue",
-                        "name": "numCallsInPriorityQueue",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the Internal Housekeeping Requests queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -115,7 +117,8 @@
                         "id": "flushQueueLength",
                         "legend": "Current depth of the memstore flush queue",
                         "metric": "flushQueueLength",
-                        "name": "flushQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the memstore flush queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -130,7 +133,8 @@
                         "id": "compactionQueueLength",
                         "legend": "Current depth of the compaction request queue",
                         "metric": "compactionQueueLength",
-                        "name": "compactionQueueLength",
+                        "metricSource": "RegionServer",
+                        "name": "Current depth of the compaction request queue",
                         "rate": false,
                         "rateoptions": {
                             "counter": true,
@@ -161,7 +165,8 @@
                         "id": "slowAppendCount",
                         "legend": "The number of slow append operations",
                         "metric": "slowAppendCount",
-                        "name": "slowAppendCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow append operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -171,7 +176,8 @@
                         "id": "slowDeleteCount",
                         "legend": "The number of slow delete operations",
                         "metric": "slowDeleteCount",
-                        "name": "slowDeleteCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow delete operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -181,7 +187,8 @@
                         "id": "slowGetCount",
                         "legend": "The number of slow get operations",
                         "metric": "slowGetCount",
-                        "name": "slowGetCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow get operations",
                         "rate": false,
                         "type": "line"
                     },
@@ -191,7 +198,8 @@
                         "id": "slowIncrementCount",
                         "legend": "The number of slow increment operations",
                         "metric": "slowIncrementCount",
-                        "name": "slowIncrementCount",
+                        "metricSource": "RegionServer",
+                        "name": "The number of slow increment operations",
                         "rate": false,
                         "type": "line"
                     }
@@ -217,7 +225,8 @@
                         "id": "totalRequestCount",
                         "legend": "The total number of requests received",
                         "metric": "totalRequestCount",
-                        "name": "totalRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -227,7 +236,8 @@
                         "id": "readRequestCount",
                         "legend": "The total number of read requests received",
                         "metric": "readRequestCount",
-                        "name": "readRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of read requests received",
                         "rate": false,
                         "type": "line"
                     },
@@ -237,7 +247,8 @@
                         "id": "writeRequestCount",
                         "legend": "The total number of write requests received",
                         "metric": "writeRequestCount",
-                        "name": "writeRequestCount",
+                        "metricSource": "RegionServer",
+                        "name": "The total number of write requests received",
                         "rate": false,
                         "type": "line"
                     }


### PR DESCRIPTION
There was no data-points when monitoring CC from RM,
therefore respective graphs wasn't displaying data.

This is additional fix for https://github.com/zenoss/zenoss-service/pull/327
Add new metric source for graph datapoints and change datapoints name to the same as legend.

[Jira](https://jira.zenoss.com/browse/ZEN-25579)
