### PR TITLE
Initialize solr on service startup

### DIFF
--- a/services/datastack/Infrastructure/Solr/-CONFIGS-/opt/solr/zenoss/etc/solr.in.sh
+++ b/services/datastack/Infrastructure/Solr/-CONFIGS-/opt/solr/zenoss/etc/solr.in.sh
@@ -1,0 +1,3 @@
+# This file is injected by ControlCenter with container-specific parameters
+ZK_HOST={{with $zks := (child (child (parent .) "HBase") "ZooKeeper").Instances }}{{range (each $zks)}}127.0.0.1:{{plus 2181 .}}{{if ne (plus 1 .) $zks}},{{end}}{{end}}{{end}}/solr
+

--- a/services/datastack/Infrastructure/Solr/service.json
+++ b/services/datastack/Infrastructure/Solr/service.json
@@ -1,6 +1,6 @@
 {
     "CPUCommitment": 2,
-    "Command": "setuser solr /opt/solr/bin/solr -f -cloud -s /opt/solr/server/solr -Dsolr.data.dir=/var/solr/data -z {{with $zks := (child (child (parent .) \"HBase\") \"ZooKeeper\").Instances }}{{range (each $zks)}}127.0.0.1:{{plus 2181 .}}{{if ne (plus 1 .) $zks}},{{end}}{{end}}{{end}}/solr",
+    "Command": "setuser solr /opt/solr/zenoss/bin/start-solr -cloud",
     "ConfigFiles": {
         "/opt/solr/server/solr/solr.xml": {
             "FileName": "/opt/solr/server/solr/solr.xml",

--- a/services/datastack/Infrastructure/Solr/service.json
+++ b/services/datastack/Infrastructure/Solr/service.json
@@ -6,6 +6,11 @@
             "FileName": "/opt/solr/server/solr/solr.xml",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/opt/solr/zenoss/etc/solr.in.sh": {
+            "Filename": "/opt/solr/zenoss/etc/solr.in.sh",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",
@@ -38,7 +43,7 @@
             "Script": "{ echo stats; sleep 1; } | nc 127.0.0.1 2181 | grep -q Zookeeper"
         }
     },
-    "ImageID": "zenoss/solr:0.0.1",
+    "ImageID": "zenoss/solr:0.0.2",
     "Instances": {
         "Default": 1,
         "Min": 1


### PR DESCRIPTION
- Add per container solr configuration file
- Initialize solr on startup.

Note that this service definition uses a version of the zenoss/solr image which has not yet been pushed to docker hub; please do not merge until that has occurred.

See related https://github.com/zenoss/solr-image/pull/2