### PR TITLE
Update SERVICED_ARCHIVE for audit logging

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -122,7 +122,7 @@ mrclean: clean
 #       by git SHA, but starting with CC 1.1.4 and RM 5.1.3, the naming convention
 #       for the tgz artifacts was updated to use CC version and build number.
 ZENPIPPKGSURL = http://zenpip.zendev.org/packages
-SERVICED_ARCHIVE=serviced-1.3.0-0.0.76.unstable.tgz
+SERVICED_ARCHIVE=serviced-1.4.0-0.0.39.unstable.tgz
 serviced:
 	echo " extracting: $@"
 	curl -s $(ZENPIPPKGSURL)/$(SERVICED_ARCHIVE) | \


### PR DESCRIPTION
https://github.com/control-center/serviced/pull/3479 added a new property, `IsAudit`, to the `LogConfig` object.  

This PR picks up the latest CC build which includes that change so that service definitions can be compiled with the new property.

Fix CC-3484