### PR TITLE
ZPS-1288: Remove terminal escape sequences from config files.

### DIFF
--- a/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/localhost/zenwebtx/-CONFIGS-/opt/zenoss/etc/zenwebtx.conf
+++ b/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/localhost/zenwebtx/-CONFIGS-/opt/zenoss/etc/zenwebtx.conf
@@ -1,4 +1,4 @@
-[?1034h#
+#
 # Configuration file for zenwebtx
 #
 #  To enable a particular option, uncomment the desired entry.

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/localhost/zenwebtx/-CONFIGS-/opt/zenoss/etc/zenwebtx.conf
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/localhost/zenwebtx/-CONFIGS-/opt/zenoss/etc/zenwebtx.conf
@@ -1,4 +1,4 @@
-[?1034h#
+#
 # Configuration file for zenwebtx
 #
 #  To enable a particular option, uncomment the desired entry.

--- a/services/Zenoss.saas/localhost/localhost/zenwebtx/-CONFIGS-/opt/zenoss/etc/zenwebtx.conf
+++ b/services/Zenoss.saas/localhost/localhost/zenwebtx/-CONFIGS-/opt/zenoss/etc/zenwebtx.conf
@@ -1,4 +1,4 @@
-[?1034h#
+#
 # Configuration file for zenwebtx
 #
 #  To enable a particular option, uncomment the desired entry.


### PR DESCRIPTION
Fixes [ZPS-1288](https://jira.zenoss.com/browse/ZPS-1288).