### PR TITLE
Update StartLevel so regionservers stop before hmaster

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
@@ -326,7 +326,7 @@
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",
-    "StartLevel": 1,
+    "StartLevel": 2,
     "Tags": [
         "daemon"
     ],

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
@@ -73,7 +73,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/service.json
@@ -6,7 +6,7 @@
     },
     "Launch": "auto",
     "Name": "opentsdb",
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "opentsdb"
     ]

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/writer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/writer/service.json
@@ -63,7 +63,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.core.full/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.core.full/Zenoss/Metrics/CentralQuery/service.json
@@ -283,7 +283,7 @@
     },
     "Name": "central_query",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.core.full/Zenoss/Metrics/MetricConsumer/service.json
+++ b/services/Zenoss.core.full/Zenoss/Metrics/MetricConsumer/service.json
@@ -392,7 +392,7 @@
     },
     "Name": "metric_consumer",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
@@ -326,7 +326,7 @@
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",
-    "StartLevel": 1,
+    "StartLevel": 2,
     "Tags": [
         "daemon"
     ],

--- a/services/Zenoss.core/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.core/Infrastructure/opentsdb/service.json
@@ -76,7 +76,7 @@
     ],
     "RAMCommitment": "256M",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.core/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.core/Zenoss/Metrics/CentralQuery/service.json
@@ -283,7 +283,7 @@
     },
     "Name": "central_query",
     "RAMCommitment": "1024M",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.core/Zenoss/Metrics/MetricConsumer/service.json
+++ b/services/Zenoss.core/Zenoss/Metrics/MetricConsumer/service.json
@@ -392,7 +392,7 @@
     },
     "Name": "metric_consumer",
     "RAMCommitment": "256M",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
@@ -326,7 +326,7 @@
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",
-    "StartLevel": 1,
+    "StartLevel": 2,
     "Tags": [
         "daemon"
     ],

--- a/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/service.json
@@ -76,7 +76,7 @@
     ],
     "RAMCommitment": "256M",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.resmgr.lite/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Metrics/CentralQuery/service.json
@@ -283,7 +283,7 @@
     },
     "Name": "central_query",
     "RAMCommitment": "1024M",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.resmgr.lite/Zenoss/Metrics/MetricConsumer/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Metrics/MetricConsumer/service.json
@@ -392,7 +392,7 @@
     },
     "Name": "metric_consumer",
     "RAMCommitment": "256M",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
@@ -326,7 +326,7 @@
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",
-    "StartLevel": 1,
+    "StartLevel": 2,
     "Tags": [
         "daemon"
     ],

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
@@ -73,7 +73,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/service.json
@@ -6,7 +6,7 @@
     },
     "Launch": "auto",
     "Name": "opentsdb",
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "opentsdb"
     ]

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/service.json
@@ -63,7 +63,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.resmgr/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Metrics/CentralQuery/service.json
@@ -283,7 +283,7 @@
     },
     "Name": "central_query",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/Zenoss.resmgr/Zenoss/Metrics/MetricConsumer/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Metrics/MetricConsumer/service.json
@@ -392,7 +392,7 @@
     },
     "Name": "metric_consumer",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/nfvi/Infrastructure/HBase/RegionServer/service.json
+++ b/services/nfvi/Infrastructure/HBase/RegionServer/service.json
@@ -326,7 +326,7 @@
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",
-    "StartLevel": 1,
+    "StartLevel": 2,
     "Tags": [
         "daemon"
     ],

--- a/services/nfvi/Infrastructure/opentsdb/reader/service.json
+++ b/services/nfvi/Infrastructure/opentsdb/reader/service.json
@@ -73,7 +73,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/nfvi/Infrastructure/opentsdb/service.json
+++ b/services/nfvi/Infrastructure/opentsdb/service.json
@@ -6,7 +6,7 @@
     },
     "Launch": "auto",
     "Name": "opentsdb",
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "opentsdb"
     ]

--- a/services/nfvi/Infrastructure/opentsdb/writer/service.json
+++ b/services/nfvi/Infrastructure/opentsdb/writer/service.json
@@ -63,7 +63,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/nfvi/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/nfvi/Zenoss/Metrics/CentralQuery/service.json
@@ -283,7 +283,7 @@
     },
     "Name": "central_query",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/nfvi/Zenoss/Metrics/MetricConsumer/service.json
+++ b/services/nfvi/Zenoss/Metrics/MetricConsumer/service.json
@@ -392,7 +392,7 @@
     },
     "Name": "metric_consumer",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
@@ -326,7 +326,7 @@
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",
-    "StartLevel": 1,
+    "StartLevel": 2,
     "Tags": [
         "daemon"
     ],

--- a/services/ucspm.lite/Infrastructure/opentsdb/service.json
+++ b/services/ucspm.lite/Infrastructure/opentsdb/service.json
@@ -76,7 +76,7 @@
     ],
     "RAMCommitment": "256M",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/ucspm.lite/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/ucspm.lite/Zenoss/Metrics/CentralQuery/service.json
@@ -283,7 +283,7 @@
     },
     "Name": "central_query",
     "RAMCommitment": "1024M",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/ucspm.lite/Zenoss/Metrics/MetricConsumer/service.json
+++ b/services/ucspm.lite/Zenoss/Metrics/MetricConsumer/service.json
@@ -392,7 +392,7 @@
     },
     "Name": "metric_consumer",
     "RAMCommitment": "256M",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/ucspm/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/service.json
@@ -326,7 +326,7 @@
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",
-    "StartLevel": 1,
+    "StartLevel": 2,
     "Tags": [
         "daemon"
     ],

--- a/services/ucspm/Infrastructure/opentsdb/reader/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/reader/service.json
@@ -73,7 +73,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/ucspm/Infrastructure/opentsdb/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/service.json
@@ -6,7 +6,7 @@
     },
     "Launch": "auto",
     "Name": "opentsdb",
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "opentsdb"
     ]

--- a/services/ucspm/Infrastructure/opentsdb/writer/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/writer/service.json
@@ -63,7 +63,7 @@
     ],
     "RAMCommitment": "1G",
     "Services": [],
-    "StartLevel": 2,
+    "StartLevel": 3,
     "Tags": [
         "daemon"
     ]

--- a/services/ucspm/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/ucspm/Zenoss/Metrics/CentralQuery/service.json
@@ -283,7 +283,7 @@
     },
     "Name": "central_query",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]

--- a/services/ucspm/Zenoss/Metrics/MetricConsumer/service.json
+++ b/services/ucspm/Zenoss/Metrics/MetricConsumer/service.json
@@ -392,7 +392,7 @@
     },
     "Name": "metric_consumer",
     "RAMCommitment": "1G",
-    "StartLevel": 3,
+    "StartLevel": 4,
     "Tags": [
         "daemon"
     ]


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-27299
See also: https://github.com/zenoss/zenoss-prodbin/pull/2292

Increase the StartLevel for the Regionserver service so that the Regionserver service is stop before the HMaster service.  Opentsdb depends on Regionserver, so bumped that also.