### PR TITLE
ZEN-27333 Add metrics collection to zproxy

### DIFF
--- a/services/Zenoss.core.full/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
+++ b/services/Zenoss.core.full/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
@@ -1,0 +1,39 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/zproxy_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:redis]
+command=redis-server /etc/redis.conf
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy]
+command=/opt/zenoss/zproxy/sbin/zproxy start
+directory=/opt/zenoss
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.core.full/service.json
+++ b/services/Zenoss.core.full/service.json
@@ -1,7 +1,13 @@
 {
     "CPUCommitment": 1,
-    "Command": "redis-server /etc/redis.conf & /bin/sh -c \"cd /opt/zenoss && exec ./zproxy/sbin/zproxy start\"",
+    "Command": "/bin/supervisord -n -c /etc/zproxy/zproxy_supervisor.conf",
     "ConfigFiles": {
+        "/etc/zproxy/zproxy_supervisor.conf": {
+            "Content": "[supervisord]\nnodaemon=true\nlogfile = /opt/zenoss/log/zproxy_supervisord.log\n\n[unix_http_server]\nfile=/tmp/supervisor.sock\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket\n\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[program:redis]\ncommand=redis-server /etc/redis.conf\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy]\ncommand=/opt/zenoss/zproxy/sbin/zproxy start\ndirectory=/opt/zenoss\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy\nautorestart=true\nautostart=true\nstartsecs=5\n\n; logging\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n",
+            "Filename": "/etc/zproxy/zproxy_supervisor.conf",
+            "Owner": "zenoss:zenoss",
+            "Permissions": "644"
+        },
         "/opt/zenoss/zproxy/conf/zproxy-nginx.conf": {
             "Filename": "/opt/zenoss/zproxy/conf/zproxy-nginx.conf",
             "Owner": "zenoss:zenoss",

--- a/services/Zenoss.core/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
+++ b/services/Zenoss.core/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
@@ -1,0 +1,39 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/zproxy_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:redis]
+command=redis-server /etc/redis.conf
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy]
+command=/opt/zenoss/zproxy/sbin/zproxy start
+directory=/opt/zenoss
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.core/service.json
+++ b/services/Zenoss.core/service.json
@@ -1,7 +1,13 @@
 {
     "CPUCommitment": 1,
-    "Command": "redis-server /etc/redis.conf & /bin/sh -c \"cd /opt/zenoss && exec ./zproxy/sbin/zproxy start\"",
+    "Command": "/bin/supervisord -n -c /etc/zproxy/zproxy_supervisor.conf",
     "ConfigFiles": {
+        "/etc/zproxy/zproxy_supervisor.conf": {
+            "Content": "[supervisord]\nnodaemon=true\nlogfile = /opt/zenoss/log/zproxy_supervisord.log\n\n[unix_http_server]\nfile=/tmp/supervisor.sock\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket\n\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[program:redis]\ncommand=redis-server /etc/redis.conf\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy]\ncommand=/opt/zenoss/zproxy/sbin/zproxy start\ndirectory=/opt/zenoss\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy\nautorestart=true\nautostart=true\nstartsecs=5\n\n; logging\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n",
+            "Filename": "/etc/zproxy/zproxy_supervisor.conf",
+            "Owner": "zenoss:zenoss",
+            "Permissions": "644"
+        },
         "/opt/zenoss/zproxy/conf/zproxy-nginx.conf": {
             "Filename": "/opt/zenoss/zproxy/conf/zproxy-nginx.conf",
             "Owner": "zenoss:zenoss",

--- a/services/Zenoss.resmgr.lite/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
+++ b/services/Zenoss.resmgr.lite/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
@@ -1,0 +1,39 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/zproxy_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:redis]
+command=redis-server /etc/redis.conf
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy]
+command=/opt/zenoss/zproxy/sbin/zproxy start
+directory=/opt/zenoss
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.resmgr.lite/service.json
+++ b/services/Zenoss.resmgr.lite/service.json
@@ -1,7 +1,13 @@
 {
     "CPUCommitment": 1,
-    "Command": "redis-server /etc/redis.conf & /bin/sh -c \"cd /opt/zenoss && exec ./zproxy/sbin/zproxy start\"",
+    "Command": "/bin/supervisord -n -c /etc/zproxy/zproxy_supervisor.conf",
     "ConfigFiles": {
+        "/etc/zproxy/zproxy_supervisor.conf": {
+            "Content": "[supervisord]\nnodaemon=true\nlogfile = /opt/zenoss/log/zproxy_supervisord.log\n\n[unix_http_server]\nfile=/tmp/supervisor.sock\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket\n\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[program:redis]\ncommand=redis-server /etc/redis.conf\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy]\ncommand=/opt/zenoss/zproxy/sbin/zproxy start\ndirectory=/opt/zenoss\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy\nautorestart=true\nautostart=true\nstartsecs=5\n\n; logging\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n",
+            "Filename": "/etc/zproxy/zproxy_supervisor.conf",
+            "Owner": "zenoss:zenoss",
+            "Permissions": "644"
+        },
         "/opt/zenoss/zproxy/conf/zproxy-nginx.conf": {
             "Filename": "/opt/zenoss/zproxy/conf/zproxy-nginx.conf",
             "Owner": "zenoss:zenoss",

--- a/services/Zenoss.resmgr/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
+++ b/services/Zenoss.resmgr/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
@@ -1,0 +1,39 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/zproxy_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:redis]
+command=redis-server /etc/redis.conf
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy]
+command=/opt/zenoss/zproxy/sbin/zproxy start
+directory=/opt/zenoss
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.resmgr/service.json
+++ b/services/Zenoss.resmgr/service.json
@@ -1,7 +1,13 @@
 {
     "CPUCommitment": 1,
-    "Command": "redis-server /etc/redis.conf & /bin/sh -c \"cd /opt/zenoss && exec ./zproxy/sbin/zproxy start\"",
+    "Command": "/bin/supervisord -n -c /etc/zproxy/zproxy_supervisor.conf",
     "ConfigFiles": {
+        "/etc/zproxy/zproxy_supervisor.conf": {
+            "Content": "[supervisord]\nnodaemon=true\nlogfile = /opt/zenoss/log/zproxy_supervisord.log\n\n[unix_http_server]\nfile=/tmp/supervisor.sock\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket\n\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[program:redis]\ncommand=redis-server /etc/redis.conf\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy]\ncommand=/opt/zenoss/zproxy/sbin/zproxy start\ndirectory=/opt/zenoss\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy\nautorestart=true\nautostart=true\nstartsecs=5\n\n; logging\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n",
+            "Filename": "/etc/zproxy/zproxy_supervisor.conf",
+            "Owner": "zenoss:zenoss",
+            "Permissions": "644"
+        },
         "/opt/zenoss/zproxy/conf/zproxy-nginx.conf": {
             "Filename": "/opt/zenoss/zproxy/conf/zproxy-nginx.conf",
             "Owner": "zenoss:zenoss",

--- a/services/ucspm.lite/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
+++ b/services/ucspm.lite/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
@@ -1,0 +1,39 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/zproxy_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:redis]
+command=redis-server /etc/redis.conf
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy]
+command=/opt/zenoss/zproxy/sbin/zproxy start
+directory=/opt/zenoss
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/ucspm.lite/service.json
+++ b/services/ucspm.lite/service.json
@@ -1,7 +1,13 @@
 {
     "CPUCommitment": 1,
-    "Command": "redis-server /etc/redis.conf & /bin/sh -c \"cd /opt/zenoss && exec ./zproxy/sbin/zproxy start\"",
+    "Command": "/bin/supervisord -n -c /etc/zproxy/zproxy_supervisor.conf",
     "ConfigFiles": {
+        "/etc/zproxy/zproxy_supervisor.conf": {
+            "Content": "[supervisord]\nnodaemon=true\nlogfile = /opt/zenoss/log/zproxy_supervisord.log\n\n[unix_http_server]\nfile=/tmp/supervisor.sock\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket\n\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[program:redis]\ncommand=redis-server /etc/redis.conf\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy]\ncommand=/opt/zenoss/zproxy/sbin/zproxy start\ndirectory=/opt/zenoss\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy\nautorestart=true\nautostart=true\nstartsecs=5\n\n; logging\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n",
+            "Filename": "/etc/zproxy/zproxy_supervisor.conf",
+            "Owner": "zenoss:zenoss",
+            "Permissions": "644"
+        },
         "/opt/zenoss/zproxy/conf/zproxy-nginx.conf": {
             "Filename": "/opt/zenoss/zproxy/conf/zproxy-nginx.conf",
             "Owner": "zenoss:zenoss",

--- a/services/ucspm/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
+++ b/services/ucspm/-CONFIGS-/etc/zproxy/zproxy_supervisor.conf
@@ -1,0 +1,39 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/zproxy_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:redis]
+command=redis-server /etc/redis.conf
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy]
+command=/opt/zenoss/zproxy/sbin/zproxy start
+directory=/opt/zenoss
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:zproxy_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/ucspm/service.json
+++ b/services/ucspm/service.json
@@ -1,7 +1,13 @@
 {
     "CPUCommitment": 1,
-    "Command": "redis-server /etc/redis.conf & /bin/sh -c \"cd /opt/zenoss && exec ./zproxy/sbin/zproxy start\"",
+    "Command": "/bin/supervisord -n -c /etc/zproxy/zproxy_supervisor.conf",
     "ConfigFiles": {
+        "/etc/zproxy/zproxy_supervisor.conf": {
+            "Content": "[supervisord]\nnodaemon=true\nlogfile = /opt/zenoss/log/zproxy_supervisord.log\n\n[unix_http_server]\nfile=/tmp/supervisor.sock\n\n[supervisorctl]\nserverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket\n\n[rpcinterface:supervisor]\nsupervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface\n\n[program:redis]\ncommand=redis-server /etc/redis.conf\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy]\ncommand=/opt/zenoss/zproxy/sbin/zproxy start\ndirectory=/opt/zenoss\nautorestart=true\nautostart=true\nstartsecs=5\npriority=1\n\n[program:zproxy_metrics]\ncommand=/usr/bin/python /opt/zenoss/bin/metrics/zenossStatsView.py zproxy\nautorestart=true\nautostart=true\nstartsecs=5\n\n; logging\nredirect_stderr=true\nstdout_logfile_maxbytes=10MB\nstdout_logfile_backups=10\nstdout_logfile=/opt/zenoss/log/%(program_name)s.log\n",
+            "Filename": "/etc/zproxy/zproxy_supervisor.conf",
+            "Owner": "zenoss:zenoss",
+            "Permissions": "644"
+        },
         "/opt/zenoss/zproxy/conf/zproxy-nginx.conf": {
             "Filename": "/opt/zenoss/zproxy/conf/zproxy-nginx.conf",
             "Owner": "zenoss:zenoss",


### PR DESCRIPTION
Zproxy has been updated for Zenoss.core, Zenoss.core.full, Zenoss.resmgr, and Zenoss.resmgr.lite.
Zproxy is now run via supervisord.
New zenossStatsView.py process added to zproxy supervisord process to track metrics.