### PR TITLE
Fix/ZEN-27867: backport #415 to disable zendebug VHost by default

### DIFF
--- a/services/Zenoss.resmgr/service.json
+++ b/services/Zenoss.resmgr/service.json
@@ -52,10 +52,19 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "export",
-            "Vhosts": [
-                "zenoss5",
-                "zendebug",
-                "zenapi"
+            "VHostList": [
+                {
+                    "Enabled": true,
+                    "Name": "zenoss5"
+                },
+                {
+                    "Enabled": false,
+                    "Name": "zendebug"
+                },
+                {
+                    "Enabled": true,
+                    "Name": "zenapi"
+                }
             ]
         },
         {

--- a/services/ucspm/service.json
+++ b/services/ucspm/service.json
@@ -60,9 +60,15 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "export",
-            "Vhosts": [
-                "zendebug",
-                "zenapi"
+            "VHostList": [
+                {
+                    "Enabled": false,
+                    "Name": "zendebug"
+                },
+                {
+                    "Enabled": true,
+                    "Name": "zenapi"
+                }
             ]
         },
         {


### PR DESCRIPTION
Backport fix/ZEN-27858: zendebug public VHost should be disabled by default