### PR TITLE
ZEN-27918: Rename Solr endpoint to zodb_solr. 

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/Solr/service.json
+++ b/services/Zenoss.core.full/Infrastructure/Solr/service.json
@@ -22,7 +22,7 @@
     "EmergencyShutdownLevel": 1,
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/service.json
@@ -78,13 +78,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core.full/Zenoss/Events/zenactiond/service.json
+++ b/services/Zenoss.core.full/Zenoss/Events/zenactiond/service.json
@@ -64,13 +64,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core.full/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.core.full/Zenoss/Events/zeneventd/service.json
@@ -57,13 +57,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core.full/Zenoss/User Interface/Zauth/service.json
+++ b/services/Zenoss.core.full/Zenoss/User Interface/Zauth/service.json
@@ -63,13 +63,6 @@
             "PortNumber": 6379,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core.full/Zenoss/User Interface/zenjobs/service.json
+++ b/services/Zenoss.core.full/Zenoss/User Interface/zenjobs/service.json
@@ -71,13 +71,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core/Infrastructure/Solr/service.json
+++ b/services/Zenoss.core/Infrastructure/Solr/service.json
@@ -22,7 +22,7 @@
     "EmergencyShutdownLevel": 1,
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/Zenoss.core/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.core/Zenoss/Collection/localhost/zenhub/service.json
@@ -78,13 +78,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core/Zenoss/Events/zenactiond/service.json
+++ b/services/Zenoss.core/Zenoss/Events/zenactiond/service.json
@@ -64,13 +64,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.core/Zenoss/Events/zeneventd/service.json
@@ -57,13 +57,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.core/Zenoss/User Interface/Zope/service.json
@@ -148,13 +148,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core/Zenoss/User Interface/zenjobs/service.json
+++ b/services/Zenoss.core/Zenoss/User Interface/zenjobs/service.json
@@ -71,13 +71,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr.lite/Infrastructure/Solr/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/Solr/service.json
@@ -22,7 +22,7 @@
     "EmergencyShutdownLevel": 1,
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhub/service.json
@@ -71,13 +71,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr.lite/Zenoss/Events/zenactiond/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Events/zenactiond/service.json
@@ -57,13 +57,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr.lite/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Events/zeneventd/service.json
@@ -50,13 +50,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr.lite/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/User Interface/Zope/service.json
@@ -155,13 +155,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr.lite/Zenoss/User Interface/zenjobs/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/User Interface/zenjobs/service.json
@@ -64,13 +64,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Infrastructure/Solr/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/Solr/service.json
@@ -22,7 +22,7 @@
     "EmergencyShutdownLevel": 1,
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/service.json
@@ -78,13 +78,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/Events/zenactiond/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Events/zenactiond/service.json
@@ -64,13 +64,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Events/zeneventd/service.json
@@ -57,13 +57,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/User Interface/Zauth/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/Zauth/service.json
@@ -61,13 +61,6 @@
             "PortNumber": 6379,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/Zope/service.json
@@ -148,13 +148,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/User Interface/zenapi/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/zenapi/service.json
@@ -91,13 +91,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/User Interface/zendebug/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/zendebug/service.json
@@ -148,13 +148,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/User Interface/zenjobs/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/zenjobs/service.json
@@ -71,13 +71,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/User Interface/zenreports/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/zenreports/service.json
@@ -91,13 +91,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/datastack/Infrastructure/Solr/service.json
+++ b/services/datastack/Infrastructure/Solr/service.json
@@ -16,7 +16,7 @@
     "Description": "Solr Cloud",
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/datastack/Zenoss/Processing/Databus/MetricCatalog/service.json
+++ b/services/datastack/Zenoss/Processing/Databus/MetricCatalog/service.json
@@ -35,13 +35,6 @@
             "VirtualAddress": "zk{{ plus 1 .InstanceID }}:2181"
         },
         {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
-        },
-        {
             "Application": "kafka-broker",
             "Name": "kafka-brokers",
             "PortNumber": 9092,

--- a/services/nfvi/Infrastructure/Solr/service.json
+++ b/services/nfvi/Infrastructure/Solr/service.json
@@ -22,7 +22,7 @@
     "EmergencyShutdownLevel": 1,
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/nfvi/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/nfvi/Zenoss/Collection/localhost/zenhub/service.json
@@ -78,13 +78,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/nfvi/Zenoss/Events/zenactiond/service.json
+++ b/services/nfvi/Zenoss/Events/zenactiond/service.json
@@ -64,13 +64,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/nfvi/Zenoss/Events/zeneventd/service.json
+++ b/services/nfvi/Zenoss/Events/zeneventd/service.json
@@ -50,13 +50,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/nfvi/Zenoss/User Interface/Zauth/service.json
+++ b/services/nfvi/Zenoss/User Interface/Zauth/service.json
@@ -61,13 +61,6 @@
             "PortNumber": 6379,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/nfvi/Zenoss/User Interface/Zope/service.json
+++ b/services/nfvi/Zenoss/User Interface/Zope/service.json
@@ -137,13 +137,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/nfvi/Zenoss/User Interface/zenjobs/service.json
+++ b/services/nfvi/Zenoss/User Interface/zenjobs/service.json
@@ -71,13 +71,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm.lite/Infrastructure/Solr/service.json
+++ b/services/ucspm.lite/Infrastructure/Solr/service.json
@@ -22,7 +22,7 @@
     "EmergencyShutdownLevel": 1,
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/ucspm.lite/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/ucspm.lite/Zenoss/Collection/localhost/zenhub/service.json
@@ -71,13 +71,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm.lite/Zenoss/Events/zenactiond/service.json
+++ b/services/ucspm.lite/Zenoss/Events/zenactiond/service.json
@@ -57,13 +57,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm.lite/Zenoss/Events/zeneventd/service.json
+++ b/services/ucspm.lite/Zenoss/Events/zeneventd/service.json
@@ -50,13 +50,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm.lite/Zenoss/User Interface/Zope/service.json
+++ b/services/ucspm.lite/Zenoss/User Interface/Zope/service.json
@@ -155,13 +155,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm.lite/Zenoss/User Interface/zenjobs/service.json
+++ b/services/ucspm.lite/Zenoss/User Interface/zenjobs/service.json
@@ -64,13 +64,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Infrastructure/Solr/service.json
+++ b/services/ucspm/Infrastructure/Solr/service.json
@@ -22,7 +22,7 @@
     "EmergencyShutdownLevel": 1,
     "Endpoints": [
         {
-            "Application": "solr",
+            "Application": "zodb_solr",
             "Name": "solr",
             "PortNumber": 8983,
             "Protocol": "tcp",

--- a/services/ucspm/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/ucspm/Zenoss/Collection/localhost/zenhub/service.json
@@ -78,13 +78,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/Events/zenactiond/service.json
+++ b/services/ucspm/Zenoss/Events/zenactiond/service.json
@@ -64,13 +64,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/Events/zeneventd/service.json
+++ b/services/ucspm/Zenoss/Events/zeneventd/service.json
@@ -57,13 +57,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/User Interface/Zauth/service.json
+++ b/services/ucspm/Zenoss/User Interface/Zauth/service.json
@@ -61,13 +61,6 @@
             "PortNumber": 6379,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/User Interface/Zope/service.json
+++ b/services/ucspm/Zenoss/User Interface/Zope/service.json
@@ -148,13 +148,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/User Interface/zenapi/service.json
+++ b/services/ucspm/Zenoss/User Interface/zenapi/service.json
@@ -91,13 +91,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/User Interface/zendebug/service.json
+++ b/services/ucspm/Zenoss/User Interface/zendebug/service.json
@@ -148,13 +148,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/User Interface/zenjobs/service.json
+++ b/services/ucspm/Zenoss/User Interface/zenjobs/service.json
@@ -71,13 +71,6 @@
             "PortNumber": 8080,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/User Interface/zenreports/service.json
+++ b/services/ucspm/Zenoss/User Interface/zenreports/service.json
@@ -91,13 +91,6 @@
             "PortNumber": 8444,
             "Protocol": "tcp",
             "Purpose": "import"
-        },
-        {
-            "Application": "solr",
-            "Name": "solr",
-            "PortNumber": 8983,
-            "Protocol": "tcp",
-            "Purpose": "import"
         }
     ],
     "HealthChecks": {


### PR DESCRIPTION
This takes advantage of the standard zodb_.* endpoint, so that wherever zodb is used, Solr is made available, without an explicit import.