### PR TITLE
Fix the rabbitmq log file name and location for all 8 products.

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/RabbitMQ/service.json
+++ b/services/Zenoss.core.full/Infrastructure/RabbitMQ/service.json
@@ -97,11 +97,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],

--- a/services/Zenoss.core/Infrastructure/RabbitMQ/service.json
+++ b/services/Zenoss.core/Infrastructure/RabbitMQ/service.json
@@ -97,11 +97,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],

--- a/services/Zenoss.resmgr.lite/Infrastructure/RabbitMQ/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/RabbitMQ/service.json
@@ -97,11 +97,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],

--- a/services/Zenoss.resmgr/Infrastructure/RabbitMQ/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/RabbitMQ/service.json
@@ -97,11 +97,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],

--- a/services/Zenoss.saas/RabbitMQ/service.json
+++ b/services/Zenoss.saas/RabbitMQ/service.json
@@ -96,11 +96,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],

--- a/services/nfvi/Infrastructure/RabbitMQ/service.json
+++ b/services/nfvi/Infrastructure/RabbitMQ/service.json
@@ -97,11 +97,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],

--- a/services/ucspm.lite/Infrastructure/RabbitMQ/service.json
+++ b/services/ucspm.lite/Infrastructure/RabbitMQ/service.json
@@ -97,11 +97,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],

--- a/services/ucspm/Infrastructure/RabbitMQ/service.json
+++ b/services/ucspm/Infrastructure/RabbitMQ/service.json
@@ -97,11 +97,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*.log",
             "type": "rabbitmq"
         },
         {
-            "path": "/var/log/rabbitmq/rabbit@localhost-sasl.log",
+            "path": "/var/log/rabbitmq/rabbit@rbt[0-9]*-sasl.log",
             "type": "rabbitmq_sasl"
         }
     ],


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-28242

Cherry picked from https://github.com/zenoss/zenoss-service/pull/437 removing the rabbitmq.conf log filters.  This was changed to make the rabbitmq servicedef log file name match the actual log file name in the container.  This will allow rabbitmq log messages to flow through logstash to elastic.