### PR TITLE
HBase and Opentsdb log filtering additions

### DIFF
--- a/services/Zenoss.core.full/FILTERS/hbasedaemon.conf
+++ b/services/Zenoss.core.full/FILTERS/hbasedaemon.conf
@@ -1,0 +1,37 @@
+#
+# This filter should be used for all HBase and OpenTsdb daemons
+#
+
+# assuming if it doesn't start with a timestamp then it is a newline
+multiline {
+    pattern => "^%{TIMESTAMP_ISO8601} "
+    negate => true
+    what => "previous"
+}
+
+grok {
+    break_on_match => true
+
+    # Matches lines of the form:
+    #
+    #
+    # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include \"/\" and \"$\"
+    # TODO: when we upgrade to a later version of grok, we could use something like this instead:
+    #    pattern_definitions => { \"JAVA_LOGGER\",  \"[a-zA-Z0-9._\\$\\-\\/]+\" }
+    #    match => [ \"message\", \"...%{JAVA_LOGGER:logger}...\"]
+    #
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime}%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}\[%{GREEDYDATA:thread}\]%{SPACE}(?<logger>[a-zA-Z0-9._\$\-\/]+)\:* %{GREEDYDATA:message}" ]
+}
+
+mutate {
+    # Convert "ss,SSS" to "ss.SSS" in case we hit some older/different logs
+    gsub => [ "datetime", "\,", "." ]
+}
+
+# This filter parses the datetime field into a time value,
+# removes the datetime field from the data, and
+# then uses the parsed value as the \"@timestamp\" for the message.
+date {
+    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+    remove_field => ["datetime"]
+}

--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
@@ -77,7 +77,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                 "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
@@ -76,11 +76,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase",
             "filters": [
-                 "hbasedaemon"
-            ]
+                "hbasedaemon"
+            ],
+            "path": "/opt/hbase/logs/hbase-master.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
@@ -72,11 +72,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase",
             "filters": [
-                 "hbasedaemon"
-            ]
+                "hbasedaemon"
+            ],
+            "path": "/opt/hbase/logs/hbase-regionserver.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
@@ -73,7 +73,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                 "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/reader/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/reader/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
@@ -61,11 +61,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-reader",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader"
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/reader/service.json
@@ -61,8 +61,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-reader"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/writer/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/writer/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/writer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/writer/service.json
@@ -55,11 +55,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-writer",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-writer"
         }
     ],
     "Name": "opentsdb-writer",

--- a/services/Zenoss.core.full/Infrastructure/opentsdb/writer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/opentsdb/writer/service.json
@@ -55,8 +55,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-writer"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-writer",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-writer",

--- a/services/Zenoss.core/FILTERS/hbasedaemon.conf
+++ b/services/Zenoss.core/FILTERS/hbasedaemon.conf
@@ -1,0 +1,37 @@
+#
+# This filter should be used for all HBase and OpenTsdb daemons
+#
+
+# assuming if it doesn't start with a timestamp then it is a newline
+multiline {
+    pattern => "^%{TIMESTAMP_ISO8601} "
+    negate => true
+    what => "previous"
+}
+
+grok {
+    break_on_match => true
+
+    # Matches lines of the form:
+    #
+    #
+    # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include \"/\" and \"$\"
+    # TODO: when we upgrade to a later version of grok, we could use something like this instead:
+    #    pattern_definitions => { \"JAVA_LOGGER\",  \"[a-zA-Z0-9._\\$\\-\\/]+\" }
+    #    match => [ \"message\", \"...%{JAVA_LOGGER:logger}...\"]
+    #
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime}%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}\[%{GREEDYDATA:thread}\]%{SPACE}(?<logger>[a-zA-Z0-9._\$\-\/]+)\:* %{GREEDYDATA:message}" ]
+}
+
+mutate {
+    # Convert "ss,SSS" to "ss.SSS" in case we hit some older/different logs
+    gsub => [ "datetime", "\,", "." ]
+}
+
+# This filter parses the datetime field into a time value,
+# removes the datetime field from the data, and
+# then uses the parsed value as the \"@timestamp\" for the message.
+date {
+    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+    remove_field => ["datetime"]
+}

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
@@ -76,11 +76,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/opt/hbase/logs/hbase-master.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
@@ -77,7 +77,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
@@ -73,7 +73,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
@@ -72,11 +72,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/opt/hbase/logs/hbase-regionserver.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.core/Infrastructure/opentsdb/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/Zenoss.core/Infrastructure/opentsdb/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/Zenoss.core/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.core/Infrastructure/opentsdb/service.json
@@ -68,8 +68,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-reader"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.core/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.core/Infrastructure/opentsdb/service.json
@@ -68,11 +68,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-reader",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader"
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.resmgr.lite/FILTERS/hbasedaemon.conf
+++ b/services/Zenoss.resmgr.lite/FILTERS/hbasedaemon.conf
@@ -1,0 +1,37 @@
+#
+# This filter should be used for all HBase and OpenTsdb daemons
+#
+
+# assuming if it doesn't start with a timestamp then it is a newline
+multiline {
+    pattern => "^%{TIMESTAMP_ISO8601} "
+    negate => true
+    what => "previous"
+}
+
+grok {
+    break_on_match => true
+
+    # Matches lines of the form:
+    #
+    #
+    # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include \"/\" and \"$\"
+    # TODO: when we upgrade to a later version of grok, we could use something like this instead:
+    #    pattern_definitions => { \"JAVA_LOGGER\",  \"[a-zA-Z0-9._\\$\\-\\/]+\" }
+    #    match => [ \"message\", \"...%{JAVA_LOGGER:logger}...\"]
+    #
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime}%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}\[%{GREEDYDATA:thread}\]%{SPACE}(?<logger>[a-zA-Z0-9._\$\-\/]+)\:* %{GREEDYDATA:message}" ]
+}
+
+mutate {
+    # Convert "ss,SSS" to "ss.SSS" in case we hit some older/different logs
+    gsub => [ "datetime", "\,", "." ]
+}
+
+# This filter parses the datetime field into a time value,
+# removes the datetime field from the data, and
+# then uses the parsed value as the \"@timestamp\" for the message.
+date {
+    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+    remove_field => ["datetime"]
+}

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
@@ -76,11 +76,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
+            "filters": [
+                "hbasedaemon"
+            ],
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase",
-             "filters": [
-                 "hbasedaemon"
-             ]
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
@@ -77,7 +77,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase"
+            "type": "hbase",
+             "filters": [
+                 "hbasedaemon"
+             ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
@@ -72,11 +72,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase",
             "filters": [
-                 "hbasedaemon"
-            ]
+                "hbasedaemon"
+            ],
+            "path": "/opt/hbase/logs/hbase-regionserver.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
@@ -73,7 +73,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                 "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/service.json
@@ -68,8 +68,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-reader"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/opentsdb/service.json
@@ -68,11 +68,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-reader",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader"
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.resmgr/FILTERS/hbasedaemon.conf
+++ b/services/Zenoss.resmgr/FILTERS/hbasedaemon.conf
@@ -1,0 +1,37 @@
+#
+# This filter should be used for all HBase and OpenTsdb daemons
+#
+
+# assuming if it doesn't start with a timestamp then it is a newline
+multiline {
+    pattern => "^%{TIMESTAMP_ISO8601} "
+    negate => true
+    what => "previous"
+}
+
+grok {
+    break_on_match => true
+
+    # Matches lines of the form:
+    #
+    #
+    # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include \"/\" and \"$\"
+    # TODO: when we upgrade to a later version of grok, we could use something like this instead:
+    #    pattern_definitions => { \"JAVA_LOGGER\",  \"[a-zA-Z0-9._\\$\\-\\/]+\" }
+    #    match => [ \"message\", \"...%{JAVA_LOGGER:logger}...\"]
+    #
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime}%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}\[%{GREEDYDATA:thread}\]%{SPACE}(?<logger>[a-zA-Z0-9._\$\-\/]+)\:* %{GREEDYDATA:message}" ]
+}
+
+mutate {
+    # Convert "ss,SSS" to "ss.SSS" in case we hit some older/different logs
+    gsub => [ "datetime", "\,", "." ]
+}
+
+# This filter parses the datetime field into a time value,
+# removes the datetime field from the data, and
+# then uses the parsed value as the \"@timestamp\" for the message.
+date {
+    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+    remove_field => ["datetime"]
+}

--- a/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
@@ -76,11 +76,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
+            "filters": [
+                "hbasedaemon"
+            ],
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase",
-             "filters": [
-                 "hbasedaemon"
-             ]
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/service.json
@@ -77,7 +77,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase"
+            "type": "hbase",
+             "filters": [
+                 "hbasedaemon"
+             ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
@@ -72,11 +72,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase",
             "filters": [
-                 "hbasedaemon"
-            ]
+                "hbasedaemon"
+            ],
+            "path": "/opt/hbase/logs/hbase-regionserver.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/service.json
@@ -73,7 +73,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                 "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
@@ -61,11 +61,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-reader",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader"
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/reader/service.json
@@ -61,8 +61,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-reader"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/service.json
@@ -55,11 +55,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-writer",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-writer"
         }
     ],
     "Name": "opentsdb-writer",

--- a/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/opentsdb/writer/service.json
@@ -55,8 +55,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-writer"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-writer",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-writer",

--- a/services/ucspm.lite/FILTERS/hbasedaemon.conf
+++ b/services/ucspm.lite/FILTERS/hbasedaemon.conf
@@ -1,0 +1,37 @@
+#
+# This filter should be used for all HBase and OpenTsdb daemons
+#
+
+# assuming if it doesn't start with a timestamp then it is a newline
+multiline {
+    pattern => "^%{TIMESTAMP_ISO8601} "
+    negate => true
+    what => "previous"
+}
+
+grok {
+    break_on_match => true
+
+    # Matches lines of the form:
+    #
+    #
+    # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include \"/\" and \"$\"
+    # TODO: when we upgrade to a later version of grok, we could use something like this instead:
+    #    pattern_definitions => { \"JAVA_LOGGER\",  \"[a-zA-Z0-9._\\$\\-\\/]+\" }
+    #    match => [ \"message\", \"...%{JAVA_LOGGER:logger}...\"]
+    #
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime}%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}\[%{GREEDYDATA:thread}\]%{SPACE}(?<logger>[a-zA-Z0-9._\$\-\/]+)\:* %{GREEDYDATA:message}" ]
+}
+
+mutate {
+    # Convert "ss,SSS" to "ss.SSS" in case we hit some older/different logs
+    gsub => [ "datetime", "\,", "." ]
+}
+
+# This filter parses the datetime field into a time value,
+# removes the datetime field from the data, and
+# then uses the parsed value as the \"@timestamp\" for the message.
+date {
+    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+    remove_field => ["datetime"]
+}

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
@@ -76,11 +76,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
+            "filters": [
+                "hbasedaemon"
+            ],
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase",
-             "filters": [
-                 "hbasedaemon"
-             ]
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
@@ -77,7 +77,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase"
+            "type": "hbase",
+             "filters": [
+                 "hbasedaemon"
+             ]
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
@@ -72,11 +72,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase",
             "filters": [
-                 "hbasedaemon"
-            ]
+                "hbasedaemon"
+            ],
+            "path": "/opt/hbase/logs/hbase-regionserver.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
@@ -73,7 +73,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                 "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm.lite/Infrastructure/opentsdb/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/ucspm.lite/Infrastructure/opentsdb/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/ucspm.lite/Infrastructure/opentsdb/service.json
+++ b/services/ucspm.lite/Infrastructure/opentsdb/service.json
@@ -68,8 +68,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-reader"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/ucspm.lite/Infrastructure/opentsdb/service.json
+++ b/services/ucspm.lite/Infrastructure/opentsdb/service.json
@@ -68,11 +68,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-reader",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader"
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/ucspm/FILTERS/hbasedaemon.conf
+++ b/services/ucspm/FILTERS/hbasedaemon.conf
@@ -1,0 +1,37 @@
+#
+# This filter should be used for all HBase and OpenTsdb daemons
+#
+
+# assuming if it doesn't start with a timestamp then it is a newline
+multiline {
+    pattern => "^%{TIMESTAMP_ISO8601} "
+    negate => true
+    what => "previous"
+}
+
+grok {
+    break_on_match => true
+
+    # Matches lines of the form:
+    #
+    #
+    # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include \"/\" and \"$\"
+    # TODO: when we upgrade to a later version of grok, we could use something like this instead:
+    #    pattern_definitions => { \"JAVA_LOGGER\",  \"[a-zA-Z0-9._\\$\\-\\/]+\" }
+    #    match => [ \"message\", \"...%{JAVA_LOGGER:logger}...\"]
+    #
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime}%{SPACE}%{LOGLEVEL:loglevel}%{SPACE}\[%{GREEDYDATA:thread}\]%{SPACE}(?<logger>[a-zA-Z0-9._\$\-\/]+)\:* %{GREEDYDATA:message}" ]
+}
+
+mutate {
+    # Convert "ss,SSS" to "ss.SSS" in case we hit some older/different logs
+    gsub => [ "datetime", "\,", "." ]
+}
+
+# This filter parses the datetime field into a time value,
+# removes the datetime field from the data, and
+# then uses the parsed value as the \"@timestamp\" for the message.
+date {
+    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+    remove_field => ["datetime"]
+}

--- a/services/ucspm/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm/Infrastructure/HBase/HMaster/service.json
@@ -76,11 +76,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
+            "filters": [
+                "hbasedaemon"
+            ],
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase",
-             "filters": [
-                 "hbasedaemon"
-             ]
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm/Infrastructure/HBase/HMaster/service.json
@@ -77,7 +77,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-master.log",
-            "type": "hbase"
+            "type": "hbase",
+             "filters": [
+                 "hbasedaemon"
+             ]
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/service.json
@@ -72,11 +72,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase",
             "filters": [
-                 "hbasedaemon"
-            ]
+                "hbasedaemon"
+            ],
+            "path": "/opt/hbase/logs/hbase-regionserver.log",
+            "type": "hbase"
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/service.json
@@ -73,7 +73,10 @@
     "LogConfigs": [
         {
             "path": "/opt/hbase/logs/hbase-regionserver.log",
-            "type": "hbase"
+            "type": "hbase",
+            "filters": [
+                 "hbasedaemon"
+            ]
         }
     ],
     "MonitoringProfile": {

--- a/services/ucspm/Infrastructure/opentsdb/reader/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/ucspm/Infrastructure/opentsdb/reader/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/ucspm/Infrastructure/opentsdb/reader/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/reader/service.json
@@ -61,11 +61,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-reader",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader"
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/ucspm/Infrastructure/opentsdb/reader/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/reader/service.json
@@ -61,8 +61,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-reader"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-reader",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-reader",

--- a/services/ucspm/Infrastructure/opentsdb/writer/-CONFIGS-/opt/opentsdb/src/logback.xml
+++ b/services/ucspm/Infrastructure/opentsdb/writer/-CONFIGS-/opt/opentsdb/src/logback.xml
@@ -4,7 +4,7 @@
   <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
       <pattern>
-        %d{ISO8601} %-5level [%thread] %logger{0}: %msg%n
+        %date{ISO8601} %-5level [%thread] %logger{0}: %msg%n
       </pattern>
     </encoder>
   </appender>
@@ -33,7 +33,7 @@
     </triggeringPolicy>
 
     <encoder>
-      <pattern>%d{HH:mm:ss.SSS} %-5level [%logger{0}.%M] - %msg%n</pattern>
+      <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 
@@ -53,7 +53,7 @@
         <maxFileSize>128MB</maxFileSize>
     </triggeringPolicy>
     <encoder>
-        <pattern>%date{ISO8601} [%logger.%M] %msg%n</pattern>
+        <pattern>%date{ISO8601} %-5level [%thread] %logger{0}: %msg%n</pattern>
     </encoder>
   </appender>
 

--- a/services/ucspm/Infrastructure/opentsdb/writer/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/writer/service.json
@@ -55,11 +55,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/var/log/opentsdb/opentsdb.log",
-            "type": "opentsdb-writer",
             "filters": [
                 "hbasedaemon"
-            ]
+            ],
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-writer"
         }
     ],
     "Name": "opentsdb-writer",

--- a/services/ucspm/Infrastructure/opentsdb/writer/service.json
+++ b/services/ucspm/Infrastructure/opentsdb/writer/service.json
@@ -55,8 +55,11 @@
     "Launch": "auto",
     "LogConfigs": [
         {
-            "path": "/opt/zenoss/log/opentsdb.log",
-            "type": "opentsdb-writer"
+            "path": "/var/log/opentsdb/opentsdb.log",
+            "type": "opentsdb-writer",
+            "filters": [
+                "hbasedaemon"
+            ]
         }
     ],
     "Name": "opentsdb-writer",


### PR DESCRIPTION
Fixes ZEN-28083 and ZEN-28344

* Add a new log filter used by HBase, RegionServer and opentsdb
* Fix opentsdb service def to use the log path specified in logback.xml
* Change logback config for opentsdb to output the same message format as HBase/RegionServer

The corresponding service migration is in this PR - https://github.com/zenoss/zenoss-prodbin/pull/2630