### PR TITLE
ZEN-27336 Collect storage metrics from HBase and Maria

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.core.full/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.core.full/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-events_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_events_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-events
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.core.full/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.core.full/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-model_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_model_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-model
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.core/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.core/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-events_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_events_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-events
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.core/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.core/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-model_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_model_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-model
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.resmgr.lite/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.resmgr.lite/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-events_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_events_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-events
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-model_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_model_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-model
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.resmgr/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.resmgr/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-events_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_events_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-events
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.resmgr/Infrastructure/mariadb-events/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/mariadb-events/service.json
@@ -1,6 +1,13 @@
 {
     "CPUCommitment": 4,
-    "Command": "/usr/bin/mysqld_safe",
+    "Command": "/bin/supervisord -n -c /etc/mariadb/mariadb_supervisor.conf",
+    "ConfigFiles": {
+        "/etc/mariadb/mariadb_supervisor.conf": {
+            "FileName": "/etc/mariadb/mariadb_supervisor.conf",
+            "Owner": "root:root",
+            "Permissions": "0664"
+        }
+    },
     "Description": "MariaDB events database server",
     "EmergencyShutdownLevel": 1,
     "Endpoints": [

--- a/services/Zenoss.resmgr/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.resmgr/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-model_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_model_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-model
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/Zenoss.resmgr/Infrastructure/mariadb-model/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/mariadb-model/service.json
@@ -1,7 +1,14 @@
 {
     "CPUCommitment": 4,
-    "Command": "/usr/bin/mysqld_safe",
+    "Command": "/bin/supervisord -n -c /etc/mariadb/mariadb_supervisor.conf",
     "Commands": {},
+    "ConfigFiles": {
+        "/etc/mariadb/mariadb_supervisor.conf": {
+            "FileName": "/etc/mariadb/mariadb_supervisor.conf",
+            "Owner": "root:root",
+            "Permissions": "0664"
+        }
+    },
     "Description": "MariaDB model database server",
     "EmergencyShutdownLevel": 1,
     "Endpoints": [

--- a/services/Zenoss.saas/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.saas/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/ucspm.lite/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/ucspm.lite/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-events_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_events_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-events
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/ucspm.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/ucspm.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-model_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_model_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-model
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/ucspm/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/ucspm/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/ucspm/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-events_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_events_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-events
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/services/ucspm/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/ucspm/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,0 +1,31 @@
+[supervisord]
+nodaemon=true
+logfile = /opt/zenoss/log/mariadb-model_supervisord.log
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:mariadb]
+command=/usr/bin/mysqld_safe
+autorestart=true
+autostart=true
+startsecs=5
+priority=1
+
+[program:mariadb_model_metrics]
+command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-model
+autorestart=true
+autostart=true
+startsecs=5
+
+; logging
+redirect_stderr=true
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=10
+stdout_logfile=/opt/zenoss/log/%(program_name)s.log

--- a/testdata/model/Zenoss.core.fake/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/testdata/model/Zenoss.core.fake/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics


### PR DESCRIPTION
Created gather.py variant for mariadb-model and mariadb-events in prodbin.
Modified mariadb-model and mariadb-events to gather database size metrics in prodbin.
Made changes to hadoop configs to collect additional metrics in HMaster.