### PR TITLE
ZEN-27336 Fix: Collect storage metrics from RegionServer

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,7 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w*
 hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster

--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount
+hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount,storeFile\\w*
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,7 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w*
 hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount
+hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount,storeFile\\w*
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,7 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w*
 hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount
+hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount,storeFile\\w*
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,7 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w*
 hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster

--- a/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.resmgr/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount
+hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount,storeFile\\w*
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/Zenoss.saas/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.saas/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,7 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w*
 hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster

--- a/services/Zenoss.saas/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/Zenoss.saas/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount
+hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount,storeFile\\w*
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,7 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w*
 hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount
+hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount,storeFile\\w*
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics

--- a/services/ucspm/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm/Infrastructure/HBase/HMaster/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,7 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w+
+hbase.sink.file-all.includedMetrics=Log\\w*,\\w*RegionServers,hbase\.regionserver\.\\w*,storeFile\\w*
 hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster

--- a/services/ucspm/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/-CONFIGS-/opt/hbase/conf/hadoop-metrics2-hbase.properties
@@ -24,7 +24,8 @@
 # to monitor different hbase daemons.
 
 hbase.sink.file-all.class=com.zenoss.hadoop.metrics.ControlCenterSink
-hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount
+hbase.sink.file-all.includedMetrics=numCallsInGeneralQueue,numCallsIn\\w*Queue,\\w*QueueLength,\\w*Count,\\w+RequestCount,storeFile\\w*
+hbase.sink.file-all.metricsPrefix=zenoss.hbase.
 # hbase.sink.file0.class=org.apache.hadoop.metrics2.sink.FileSink
 # hbase.sink.file0.context=hmaster
 # hbase.sink.file0.filename=master.metrics


### PR DESCRIPTION
HMaster hadoop metrics2 was not collecting the metric storeFileSize
RegionServer does.

The filters have been modified to collect storeFile\w* instead of storeFile\w+