### PR TITLE
Fixed the multiline to be explicit and handle a datetime parse failure

### DIFF
--- a/services/Zenoss.core.full/FILTERS/zeneventserver.conf
+++ b/services/Zenoss.core.full/FILTERS/zeneventserver.conf
@@ -2,16 +2,23 @@
 # This filter should be used for zeneventserver logs.
 #
 
-# new lines start with a date
+# new lines start with any of these:
+#   Example 1: "2013-10-31"
+# This one will happen but not explicitly (see below for more details)
+#   Example 2: "[INFO]"
 multiline {
-    pattern => "^\s|[A-Za-z]"
+    pattern => "^[0-9]*-[0-9]*-[0-9]*"
+    negate => true
     what => "previous"
 }
 
 grok {
     break_on_match => true
 
-    # Matches lines of the form: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    # Matches lines of the form:
+    #    Example 1: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    #    Example 2: 2017-09-13 15:20:59.803:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:8084 STARTING, Started SelectChannelConnector@0.0.0.0:8084 STARTING
+    #    Example 3: [INFO] Recreating index for table event_archive, Recreating index for table event_archive
     #
     # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include "/" and "$"
     # TODO: when we upgrade to a later version of grok, we could use something like this instead:
@@ -27,15 +34,18 @@ grok {
     match => [ "message", "\[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:message}"]
 }
 
-mutate {
-    # remove literal 'T' from datetime to make parsing in the next step easier
-    gsub => [ "datetime", "T", " " ]
-}
+# Only mutate datetime if we actually have a datetime field.
+if [datetime] {
+    mutate {
+        # remove literal 'T' from datetime to make parsing in the next step easier
+        gsub => [ "datetime", "T", " " ]
+    }
 
-# This filter parses the datetime field into a time value,
-# removes the datetime field from the data, and
-# then uses the parsed value as the "@timestamp" for the message.
-date {
-    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
-    remove_field => ["datetime"]
+    # This filter parses the datetime field into a time value,
+    # removes the datetime field from the data, and
+    # then uses the parsed value as the "@timestamp" for the message.
+    date {
+        match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+        remove_field => ["datetime"]
+    }
 }

--- a/services/Zenoss.core/FILTERS/zeneventserver.conf
+++ b/services/Zenoss.core/FILTERS/zeneventserver.conf
@@ -2,16 +2,23 @@
 # This filter should be used for zeneventserver logs.
 #
 
-# new lines start with a date
+# new lines start with any of these:
+#   Example 1: "2013-10-31"
+# This one will happen but not explicitly (see below for more details)
+#   Example 2: "[INFO]"
 multiline {
-    pattern => "^\s|[A-Za-z]"
+    pattern => "^[0-9]*-[0-9]*-[0-9]*"
+    negate => true
     what => "previous"
 }
 
 grok {
     break_on_match => true
 
-    # Matches lines of the form: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    # Matches lines of the form:
+    #    Example 1: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    #    Example 2: 2017-09-13 15:20:59.803:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:8084 STARTING, Started SelectChannelConnector@0.0.0.0:8084 STARTING
+    #    Example 3: [INFO] Recreating index for table event_archive, Recreating index for table event_archive
     #
     # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include "/" and "$"
     # TODO: when we upgrade to a later version of grok, we could use something like this instead:
@@ -27,15 +34,18 @@ grok {
     match => [ "message", "\[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:message}"]
 }
 
-mutate {
-    # remove literal 'T' from datetime to make parsing in the next step easier
-    gsub => [ "datetime", "T", " " ]
-}
+# Only mutate datetime if we actually have a datetime field.
+if [datetime] {
+    mutate {
+        # remove literal 'T' from datetime to make parsing in the next step easier
+        gsub => [ "datetime", "T", " " ]
+    }
 
-# This filter parses the datetime field into a time value,
-# removes the datetime field from the data, and
-# then uses the parsed value as the "@timestamp" for the message.
-date {
-    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
-    remove_field => ["datetime"]
+    # This filter parses the datetime field into a time value,
+    # removes the datetime field from the data, and
+    # then uses the parsed value as the "@timestamp" for the message.
+    date {
+        match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+        remove_field => ["datetime"]
+    }
 }

--- a/services/Zenoss.resmgr.lite/FILTERS/zeneventserver.conf
+++ b/services/Zenoss.resmgr.lite/FILTERS/zeneventserver.conf
@@ -2,16 +2,23 @@
 # This filter should be used for zeneventserver logs.
 #
 
-# new lines start with a date
+# new lines start with any of these:
+#   Example 1: "2013-10-31"
+# This one will happen but not explicitly (see below for more details)
+#   Example 2: "[INFO]"
 multiline {
-    pattern => "^\s|[A-Za-z]"
+    pattern => "^[0-9]*-[0-9]*-[0-9]*"
+    negate => true
     what => "previous"
 }
 
 grok {
     break_on_match => true
 
-    # Matches lines of the form: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    # Matches lines of the form:
+    #    Example 1: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    #    Example 2: 2017-09-13 15:20:59.803:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:8084 STARTING, Started SelectChannelConnector@0.0.0.0:8084 STARTING
+    #    Example 3: [INFO] Recreating index for table event_archive, Recreating index for table event_archive
     #
     # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include "/" and "$"
     # TODO: when we upgrade to a later version of grok, we could use something like this instead:
@@ -27,15 +34,18 @@ grok {
     match => [ "message", "\[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:message}"]
 }
 
-mutate {
-    # remove literal 'T' from datetime to make parsing in the next step easier
-    gsub => [ "datetime", "T", " " ]
-}
+# Only mutate datetime if we actually have a datetime field.
+if [datetime] {
+    mutate {
+        # remove literal 'T' from datetime to make parsing in the next step easier
+        gsub => [ "datetime", "T", " " ]
+    }
 
-# This filter parses the datetime field into a time value,
-# removes the datetime field from the data, and
-# then uses the parsed value as the "@timestamp" for the message.
-date {
-    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
-    remove_field => ["datetime"]
+    # This filter parses the datetime field into a time value,
+    # removes the datetime field from the data, and
+    # then uses the parsed value as the "@timestamp" for the message.
+    date {
+        match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+        remove_field => ["datetime"]
+    }
 }

--- a/services/Zenoss.resmgr/FILTERS/zeneventserver.conf
+++ b/services/Zenoss.resmgr/FILTERS/zeneventserver.conf
@@ -2,16 +2,23 @@
 # This filter should be used for zeneventserver logs.
 #
 
-# new lines start with a date
+# new lines start with any of these:
+#   Example 1: "2013-10-31"
+# This one will happen but not explicitly (see below for more details)
+#   Example 2: "[INFO]"
 multiline {
-    pattern => "^\s|[A-Za-z]"
+    pattern => "^[0-9]*-[0-9]*-[0-9]*"
+    negate => true
     what => "previous"
 }
 
 grok {
     break_on_match => true
 
-    # Matches lines of the form: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    # Matches lines of the form:
+    #    Example 1: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    #    Example 2: 2017-09-13 15:20:59.803:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:8084 STARTING, Started SelectChannelConnector@0.0.0.0:8084 STARTING
+    #    Example 3: [INFO] Recreating index for table event_archive, Recreating index for table event_archive
     #
     # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include "/" and "$"
     # TODO: when we upgrade to a later version of grok, we could use something like this instead:
@@ -27,15 +34,18 @@ grok {
     match => [ "message", "\[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:message}"]
 }
 
-mutate {
-    # remove literal 'T' from datetime to make parsing in the next step easier
-    gsub => [ "datetime", "T", " " ]
-}
+# Only mutate datetime if we actually have a datetime field.
+if [datetime] {
+    mutate {
+        # remove literal 'T' from datetime to make parsing in the next step easier
+        gsub => [ "datetime", "T", " " ]
+    }
 
-# This filter parses the datetime field into a time value,
-# removes the datetime field from the data, and
-# then uses the parsed value as the "@timestamp" for the message.
-date {
-    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
-    remove_field => ["datetime"]
+    # This filter parses the datetime field into a time value,
+    # removes the datetime field from the data, and
+    # then uses the parsed value as the "@timestamp" for the message.
+    date {
+        match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+        remove_field => ["datetime"]
+    }
 }

--- a/services/Zenoss.saas/FILTERS/zeneventserver.conf
+++ b/services/Zenoss.saas/FILTERS/zeneventserver.conf
@@ -1,15 +1,51 @@
-# new lines start with a date
+#
+# This filter should be used for zeneventserver logs.
+#
+
+# new lines start with any of these:
+#   Example 1: "2013-10-31"
+# This one will happen but not explicitly (see below for more details)
+#   Example 2: "[INFO]"
 multiline {
-    pattern => "^[A-Za-z|\s]"
+    pattern => "^[0-9]*-[0-9]*-[0-9]*"
+    negate => true
     what => "previous"
 }
 
-# drop the brackets to make parsing easier
-mutate {
-    gsub => [ "message", "\[", "" ]
-    gsub => [ "message", "\]", "" ]
-}
-# 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
 grok {
-    match => [ "message", "%{TIMESTAMP_ISO8601:time} %{WORD:component} %{LOGLEVEL:loglevel}"]
+    break_on_match => true
+
+    # Matches lines of the form:
+    #    Example 1: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    #    Example 2: 2017-09-13 15:20:59.803:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:8084 STARTING, Started SelectChannelConnector@0.0.0.0:8084 STARTING
+    #    Example 3: [INFO] Recreating index for table event_archive, Recreating index for table event_archive
+    #
+    # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include "/" and "$"
+    # TODO: when we upgrade to a later version of grok, we could use something like this instead:
+    #    pattern_definitions => { "JAVA_LOGGER",  "[a-zA-Z0-9._\$\-\/]+" }
+    #    match => [ "message", "...%{JAVA_LOGGER:logger}..."]
+    #
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime} \[%{GREEDYDATA:thread}\] %{LOGLEVEL:loglevel}%{SPACE}(?<logger>[a-zA-Z0-9._\$\-\/]+) - %{GREEDYDATA:message}"]
+
+    # The following catches messages from some of the jars in zeneventserver which log with a slightly different format
+    match => [ "message", "%{TIMESTAMP_ISO8601:datetime}\:%{LOGLEVEL:loglevel}\:(?<logger>[a-zA-Z0-9._\$\-\/]+)\:%{GREEDYDATA:message}"]
+
+    # An alternate match for debugging scenarios where Maven started the app
+    match => [ "message", "\[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:message}"]
+}
+
+# Only mutate datetime if we actually have a datetime field.
+if [datetime] {
+    mutate {
+        # remove literal 'T' from datetime to make parsing in the next step easier
+        gsub => [ "datetime", "T", " " ]
+    }
+
+    # This filter parses the datetime field into a time value,
+    # removes the datetime field from the data, and
+    # then uses the parsed value as the "@timestamp" for the message.
+    date {
+        match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+        remove_field => ["datetime"]
+    }
 }

--- a/services/ucspm.lite/FILTERS/zeneventserver.conf
+++ b/services/ucspm.lite/FILTERS/zeneventserver.conf
@@ -2,16 +2,23 @@
 # This filter should be used for zeneventserver logs.
 #
 
-# new lines start with a date
+# new lines start with any of these:
+#   Example 1: "2013-10-31"
+# This one will happen but not explicitly (see below for more details)
+#   Example 2: "[INFO]"
 multiline {
-    pattern => "^\s|[A-Za-z]"
+    pattern => "^[0-9]*-[0-9]*-[0-9]*"
+    negate => true
     what => "previous"
 }
 
 grok {
     break_on_match => true
 
-    # Matches lines of the form: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    # Matches lines of the form:
+    #    Example 1: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    #    Example 2: 2017-09-13 15:20:59.803:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:8084 STARTING, Started SelectChannelConnector@0.0.0.0:8084 STARTING
+    #    Example 3: [INFO] Recreating index for table event_archive, Recreating index for table event_archive
     #
     # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include "/" and "$"
     # TODO: when we upgrade to a later version of grok, we could use something like this instead:
@@ -27,15 +34,18 @@ grok {
     match => [ "message", "\[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:message}"]
 }
 
-mutate {
-    # remove literal 'T' from datetime to make parsing in the next step easier
-    gsub => [ "datetime", "T", " " ]
-}
+# Only mutate datetime if we actually have a datetime field.
+if [datetime] {
+    mutate {
+        # remove literal 'T' from datetime to make parsing in the next step easier
+        gsub => [ "datetime", "T", " " ]
+    }
 
-# This filter parses the datetime field into a time value,
-# removes the datetime field from the data, and
-# then uses the parsed value as the "@timestamp" for the message.
-date {
-    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
-    remove_field => ["datetime"]
+    # This filter parses the datetime field into a time value,
+    # removes the datetime field from the data, and
+    # then uses the parsed value as the "@timestamp" for the message.
+    date {
+        match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+        remove_field => ["datetime"]
+    }
 }

--- a/services/ucspm/FILTERS/zeneventserver.conf
+++ b/services/ucspm/FILTERS/zeneventserver.conf
@@ -2,16 +2,23 @@
 # This filter should be used for zeneventserver logs.
 #
 
-# new lines start with a date
+# new lines start with any of these:
+#   Example 1: "2013-10-31"
+# This one will happen but not explicitly (see below for more details)
+#   Example 2: "[INFO]"
 multiline {
-    pattern => "^\s|[A-Za-z]"
+    pattern => "^[0-9]*-[0-9]*-[0-9]*"
+    negate => true
     what => "previous"
 }
 
 grok {
     break_on_match => true
 
-    # Matches lines of the form: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    # Matches lines of the form:
+    #    Example 1: 2013-10-31T06:52:44.215 [INDEXER_EVENT_SUMMARY] ERROR org.springframework.transaction.interceptor.TransactionInterceptor - Application exception overridden by rollback exception
+    #    Example 2: 2017-09-13 15:20:59.803:INFO:oejs.AbstractConnector:Started SelectChannelConnector@0.0.0.0:8084 STARTING, Started SelectChannelConnector@0.0.0.0:8084 STARTING
+    #    Example 3: [INFO] Recreating index for table event_archive, Recreating index for table event_archive
     #
     # Note that a specialized form of the USERNAME pattern is used to capture 'logger' since java logger may include "/" and "$"
     # TODO: when we upgrade to a later version of grok, we could use something like this instead:
@@ -27,15 +34,18 @@ grok {
     match => [ "message", "\[%{LOGLEVEL:loglevel}\] %{GREEDYDATA:message}"]
 }
 
-mutate {
-    # remove literal 'T' from datetime to make parsing in the next step easier
-    gsub => [ "datetime", "T", " " ]
-}
+# Only mutate datetime if we actually have a datetime field.
+if [datetime] {
+    mutate {
+        # remove literal 'T' from datetime to make parsing in the next step easier
+        gsub => [ "datetime", "T", " " ]
+    }
 
-# This filter parses the datetime field into a time value,
-# removes the datetime field from the data, and
-# then uses the parsed value as the "@timestamp" for the message.
-date {
-    match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
-    remove_field => ["datetime"]
+    # This filter parses the datetime field into a time value,
+    # removes the datetime field from the data, and
+    # then uses the parsed value as the "@timestamp" for the message.
+    date {
+        match => [ "datetime", "yyyy-MM-dd HH:mm:ss.SSS" ]
+        remove_field => ["datetime"]
+    }
 }


### PR DESCRIPTION
This fix addresses the issue specified in https://jira.zenoss.com/browse/ZEN-28566.  