### PR TITLE
ZEN-28753: Add opentsdb writer endpoint to centralquery

### DIFF
--- a/services/Zenoss.core.full/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.core.full/Zenoss/Metrics/CentralQuery/service.json
@@ -38,6 +38,13 @@
             "PortNumber": 4242,
             "Protocol": "tcp",
             "Purpose": "import"
+        },
+        {
+            "Application": "opentsdb-writer",
+            "Name": "opentsdb-writer",
+            "PortNumber": 4243,
+            "Protocol": "tcp",
+            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.core/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.core/Zenoss/Metrics/CentralQuery/service.json
@@ -38,6 +38,13 @@
             "PortNumber": 4242,
             "Protocol": "tcp",
             "Purpose": "import"
+        },
+        {
+            "Application": "opentsdb-writer",
+            "Name": "opentsdb-writer",
+            "PortNumber": 4243,
+            "Protocol": "tcp",
+            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr.lite/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Metrics/CentralQuery/service.json
@@ -38,6 +38,13 @@
             "PortNumber": 4242,
             "Protocol": "tcp",
             "Purpose": "import"
+        },
+        {
+            "Application": "opentsdb-writer",
+            "Name": "opentsdb-writer",
+            "PortNumber": 4243,
+            "Protocol": "tcp",
+            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.resmgr/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Metrics/CentralQuery/service.json
@@ -38,6 +38,13 @@
             "PortNumber": 4242,
             "Protocol": "tcp",
             "Purpose": "import"
+        },
+        {
+            "Application": "opentsdb-writer",
+            "Name": "opentsdb-writer",
+            "PortNumber": 4243,
+            "Protocol": "tcp",
+            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/Zenoss.saas/CentralQuery/service.json
+++ b/services/Zenoss.saas/CentralQuery/service.json
@@ -38,6 +38,13 @@
             "PortNumber": 4242,
             "Protocol": "tcp",
             "Purpose": "import"
+        },
+        {
+            "Application": "opentsdb-writer",
+            "Name": "opentsdb-writer",
+            "PortNumber": 4243,
+            "Protocol": "tcp",
+            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm.lite/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/ucspm.lite/Zenoss/Metrics/CentralQuery/service.json
@@ -38,6 +38,13 @@
             "PortNumber": 4242,
             "Protocol": "tcp",
             "Purpose": "import"
+        },
+        {
+            "Application": "opentsdb-writer",
+            "Name": "opentsdb-writer",
+            "PortNumber": 4243,
+            "Protocol": "tcp",
+            "Purpose": "import"
         }
     ],
     "HealthChecks": {

--- a/services/ucspm/Zenoss/Metrics/CentralQuery/service.json
+++ b/services/ucspm/Zenoss/Metrics/CentralQuery/service.json
@@ -38,6 +38,13 @@
             "PortNumber": 4242,
             "Protocol": "tcp",
             "Purpose": "import"
+        },
+        {
+            "Application": "opentsdb-writer",
+            "Name": "opentsdb-writer",
+            "PortNumber": 4243,
+            "Protocol": "tcp",
+            "Purpose": "import"
         }
     ],
     "HealthChecks": {


### PR DESCRIPTION
in order to drop cache on writer after reidentifying a device.