### PR TITLE
CC-3937 add rateOptions for counters

### DIFF
--- a/services/Zenoss.core.full/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
+++ b/services/Zenoss.core.full/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
@@ -72,6 +72,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -98,6 +101,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -109,6 +115,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/Zenoss.core.full/Zenoss/Metrics/MetricShipper/service.json
+++ b/services/Zenoss.core.full/Zenoss/Metrics/MetricShipper/service.json
@@ -70,6 +70,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -96,6 +99,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -107,6 +113,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/Zenoss.core/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
+++ b/services/Zenoss.core/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
@@ -72,6 +72,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -98,6 +101,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -109,6 +115,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/Zenoss.core/Zenoss/Metrics/MetricShipper/service.json
+++ b/services/Zenoss.core/Zenoss/Metrics/MetricShipper/service.json
@@ -70,6 +70,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -96,6 +99,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -107,6 +113,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
@@ -72,6 +72,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -98,6 +101,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -109,6 +115,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/Zenoss.resmgr.lite/Zenoss/Metrics/MetricShipper/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Metrics/MetricShipper/service.json
@@ -70,6 +70,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -96,6 +99,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -107,6 +113,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
@@ -72,6 +72,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -98,6 +101,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -109,6 +115,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/Zenoss.resmgr/Zenoss/Metrics/MetricShipper/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Metrics/MetricShipper/service.json
@@ -70,6 +70,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -96,6 +99,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -107,6 +113,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/ucspm.lite/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
+++ b/services/ucspm.lite/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
@@ -72,6 +72,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -98,6 +101,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -109,6 +115,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/ucspm.lite/Zenoss/Metrics/MetricShipper/service.json
+++ b/services/ucspm.lite/Zenoss/Metrics/MetricShipper/service.json
@@ -70,6 +70,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -96,6 +99,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -107,6 +113,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/ucspm/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
+++ b/services/ucspm/Zenoss/Collection/localhost/localhost/MetricShipper/service.json
@@ -72,6 +72,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -98,6 +101,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -109,6 +115,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],

--- a/services/ucspm/Zenoss/Metrics/MetricShipper/service.json
+++ b/services/ucspm/Zenoss/Metrics/MetricShipper/service.json
@@ -70,6 +70,9 @@
                         "metricSource": "metricshipper",
                         "name": "tx",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],
@@ -96,6 +99,9 @@
                         "metricSource": "metricshipper",
                         "name": "outgoing",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     },
                     {
@@ -107,6 +113,9 @@
                         "metricSource": "metricshipper",
                         "name": "incoming",
                         "rate": true,
+                        "rateOptions": {
+                            "counter": true
+                        },
                         "type": "line"
                     }
                 ],


### PR DESCRIPTION
Add rateOptions for metricshipper rates datapoints to make RM graphs congruent with CC graphs;
also fix will prevent negative values in metricshipper CC graphs
[Jira](https://jira.zenoss.com/browse/CC-3937)