### PR TITLE
Remove zodb-poll-interval option from default confs

### DIFF
--- a/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.core.full/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/services/Zenoss.core.full/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.core.full/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/services/Zenoss.core.full/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.core.full/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/Zenoss.core.full/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.core/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/services/Zenoss.core/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.core/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/services/Zenoss.core/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.core/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/services/Zenoss.core/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.core/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/Zenoss.core/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@ identifier random
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr.lite/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/services/Zenoss.resmgr.lite/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr.lite/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/services/Zenoss.resmgr.lite/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr.lite/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/Zenoss.resmgr.lite/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@ identifier random
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/services/Zenoss.resmgr/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/services/Zenoss.resmgr/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.resmgr/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.saas/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/services/Zenoss.saas/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@ identifier random
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.saas/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/services/Zenoss.saas/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.saas/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/services/Zenoss.saas/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/Zenoss.saas/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/Zenoss.saas/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm.lite/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/services/ucspm.lite/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@ identifier random
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm.lite/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/services/ucspm.lite/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm.lite/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/services/ucspm.lite/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm.lite/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/ucspm.lite/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/services/ucspm/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@ identifier random
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/services/ucspm/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/services/ucspm/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/services/ucspm/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/ucspm/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/testdata/model/Zenoss.core.fake/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
+++ b/testdata/model/Zenoss.core.fake/Zenoss/Collection/localhost/zenhub/-CONFIGS-/opt/zenoss/etc/zenhub.conf
@@ -201,12 +201,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/testdata/model/Zenoss.core.fake/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
+++ b/testdata/model/Zenoss.core.fake/Zenoss/Events/zenactiond/-CONFIGS-/opt/zenoss/etc/zenactiond.conf
@@ -124,12 +124,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/testdata/model/Zenoss.core.fake/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
+++ b/testdata/model/Zenoss.core.fake/Zenoss/Events/zeneventd/-CONFIGS-/opt/zenoss/etc/zeneventd.conf
@@ -120,12 +120,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults

--- a/testdata/model/Zenoss.core.fake/Zenoss/User-Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/testdata/model/Zenoss.core.fake/Zenoss/User-Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -113,12 +113,6 @@
 #  127.0.0.1:11211
 #zodb-cacheservers 127.0.0.1:11211
 #
-# Defer polling the database for the specified
-#  maximum time interval, in seconds.
-#  This will default to 60 only if --zodb-cacheservers
-#  is set.
-#zodb-poll-interval None
-#
 # Specify the number of seconds a database
 #  connection will wait to acquire a database
 #  'commit' lock before failing (defaults


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-27806

The new version of relstorage ignores the poll-interval option and generates a warning.  Remove this as one of the parameters when connecting.

Note: We aren't removing the commented section from upgrades, but it won't be used (and won't generate a warning)