### PR TITLE
Use GCR instead of registry.zing so CSE deployment works

### DIFF
--- a/services/Zenoss.cse/Infrastructure/zing-connector/service.json
+++ b/services/Zenoss.cse/Infrastructure/zing-connector/service.json
@@ -31,7 +31,7 @@
             "Script": "test \"$(curl localhost:9237/_admin/ping)\" = \"PONG\""
         }
     },
-    "ImageId": "registry.zing.zenoss.eng/zenoss/zing-connector:975aea02",
+    "ImageId": "gcr.io/zing-registry-188222/zing-connector:975aea02",
     "Instances": {
         "Min": 1
     },


### PR DESCRIPTION
The CSE running in GCP needs to pull images from GCR, because the CSE in GCP does not have access to `registry.zing.zenoss.eng`