### PR TITLE
Refine zing connector

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,6 +19,7 @@ SHORT_VERSION   ?= 5.1
 hbase_VERSION    ?= v16
 hdfs_VERSION     ?= v4
 opentsdb_VERSION ?= v23
+zing_connector_VERSION ?= latest
 
 DOCKER          ?= $(shell which docker)
 BUILD_NUMBER    ?= $(shell date +%Y%m%d%H%M%S)
@@ -101,6 +102,10 @@ svcdef_ImageID_maps  += $(jsonsrc_hdfs_ImageID),$(desired_hdfs_ImageID)
 jsonsrc_opentsdb_ImageID = zenoss/opentsdb:xx
 desired_opentsdb_ImageID = $(docker_PREFIX)opentsdb:$(opentsdb_VERSION)
 svcdef_ImageID_maps     += $(jsonsrc_opentsdb_ImageID),$(desired_opentsdb_ImageID)
+#
+jsonsrc_zing_connector_ImageID = gcr-repo/zing-connector:xx
+desired_zing_connector_ImageID = gcr.io/zing-registry-188222/zing-connector:$(zing_connector_VERSION)
+svcdef_ImageID_maps     += $(jsonsrc_zing_connector_ImageID),$(desired_zing_connector_ImageID)
 
 .PHONY: default docker_buildimage docker_svcdefpkg-% docker_svcdef-%
 

--- a/services/Zenoss.cse/Infrastructure/zing-connector/-CONFIGS-/etc/zing-connector.yml
+++ b/services/Zenoss.cse/Infrastructure/zing-connector/-CONFIGS-/etc/zing-connector.yml
@@ -12,7 +12,7 @@ pubsub:
   project: CHANGE_ME
   tenant: CHANGE_ME
   source: CHANGE_ME
-  host-port: ""
   metric-topic: metric-raw-rm
   model-topic: model-raw-rm
-
+  # use-emulator: false
+  # host-port: <emulator-ip:emulator-port>

--- a/services/Zenoss.cse/Infrastructure/zing-connector/service.json
+++ b/services/Zenoss.cse/Infrastructure/zing-connector/service.json
@@ -31,7 +31,7 @@
             "Script": "test \"$(curl localhost:9237/_admin/ping)\" = \"PONG\""
         }
     },
-    "ImageId": "gcr.io/zing-registry-188222/zing-connector:975aea02",
+    "ImageId": "gcr-repo/zing-connector:xx",
     "Instances": {
         "Min": 1
     },


### PR DESCRIPTION
This allows us to inject the image tag for the zing-connector image.  Note that this code will be used by complimentary changes in the product-assembly repo, which are available in this [PR](https://github.com/zenoss/product-assembly/pull/661)