### PR TITLE
Removed deprecated options from zing-connector.yml

### DIFF
--- a/services/Zenoss.cse/Infrastructure/zing-connector/-CONFIGS-/etc/zing-connector.yml
+++ b/services/Zenoss.cse/Infrastructure/zing-connector/-CONFIGS-/etc/zing-connector.yml
@@ -2,12 +2,6 @@ log:
   level: info
 http:
   port: 9237
-model-ingest: 
-  path: /api/model/ingest
-  enabled: true
-metric-ingest:
-  path: /api/metrics/ingest
-  enabled: true
 pubsub:
   project: CHANGE_ME
   tenant: CHANGE_ME


### PR DESCRIPTION
Model-ingest and metric-ingest stanzas from Zenoss.cse zing-connector.yml