### PR TITLE
Restore the right image ID for zing-connector

### DIFF
--- a/services/Zenoss.cse/Infrastructure/zing-connector/service.json
+++ b/services/Zenoss.cse/Infrastructure/zing-connector/service.json
@@ -38,7 +38,7 @@
             "Script": "test \"$(curl localhost:9000/ping)\" = \"PONG\""
         }
     },
-    "ImageId": "zenoss/zing-connector:dev",
+    "ImageId": "gcr-repo/zing-connector:xx",
     "Instances": {
         "Min": 1
     },


### PR DESCRIPTION
Both zendev and the build process will swap in the right value at build time.