### PR TITLE
Lower default configsipsize from 25 to 5 in zenucsevents.conf

### DIFF
--- a/services/Zenoss.cse/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
+++ b/services/Zenoss.cse/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
@@ -141,7 +141,7 @@
 # Max number of device configurations
 #  to load at once, default %default (0
 #  == all devices), default: 25
-#configsipsize 25
+configsipsize 5
 #
 # Delay in seconds between device configurations
 #  loading, default %default, default: 1

--- a/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
+++ b/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
@@ -141,7 +141,7 @@
 # Max number of device configurations
 #  to load at once, default %default (0
 #  == all devices), default: 25
-#configsipsize 25
+configsipsize 5
 #
 # Delay in seconds between device configurations
 #  loading, default %default, default: 1

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
@@ -141,7 +141,7 @@
 # Max number of device configurations
 #  to load at once, default %default (0
 #  == all devices), default: 25
-#configsipsize 25
+configsipsize 5
 #
 # Delay in seconds between device configurations
 #  loading, default %default, default: 1

--- a/services/ucspm.lite/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
+++ b/services/ucspm.lite/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
@@ -141,7 +141,7 @@
 # Max number of device configurations
 #  to load at once, default %default (0
 #  == all devices), default: 25
-#configsipsize 25
+configsipsize 5
 #
 # Delay in seconds between device configurations
 #  loading, default %default, default: 1

--- a/services/ucspm/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
+++ b/services/ucspm/Zenoss/Collection/localhost/localhost/zenucsevents/-CONFIGS-/opt/zenoss/etc/zenucsevents.conf
@@ -141,7 +141,7 @@
 # Max number of device configurations
 #  to load at once, default %default (0
 #  == all devices), default: 25
-#configsipsize 25
+configsipsize 5
 #
 # Delay in seconds between device configurations
 #  loading, default %default, default: 1


### PR DESCRIPTION
Fixes [ZEN-29915](https://jira.zenoss.com/browse/ZEN-29915).