### PR TITLE
Default the whitelist to alphacorp; this is replaced in cse-provision

### DIFF
--- a/services/Zenoss.cse/service.json
+++ b/services/Zenoss.cse/service.json
@@ -36,7 +36,7 @@
         "global.conf.auth0-clientid": "DEpUm5pU4B5mOXmVtC9CHBmAXImveJlQ",
         "global.conf.auth0-tenant": "https://zenoss-dev.auth0.com/",
         "global.conf.auth0-tenantkey": "https://dev.zing.ninja/tenant",
-        "global.conf.auth0-whitelist": "",
+        "global.conf.auth0-whitelist": "alphacorp",
         "global.conf.cse-vhost": "testcse",
         "global.conf.cse-virtualroot": "/cz",
         "global.conf.cse-zing-host": "zing.soy",

--- a/services/Zenoss.cse/service.json
+++ b/services/Zenoss.cse/service.json
@@ -33,7 +33,6 @@
         "global.conf.amqpusessl": "0",
         "global.conf.amqpvhost": "/zenoss",
         "global.conf.auth0-audience": "https://dev.zing.ninja",
-        "global.conf.auth0-clientid": "DEpUm5pU4B5mOXmVtC9CHBmAXImveJlQ",
         "global.conf.auth0-tenant": "https://zenoss-dev.auth0.com/",
         "global.conf.auth0-tenantkey": "https://dev.zing.ninja/tenant",
         "global.conf.auth0-whitelist": "alphacorp",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-30235
Default the whitelist to alphacorp.  For a cse-deploy job, this is replaced by the tenant in provision.  For local zendev this will be alphacorp, which matches the tenant assigned via auth0 (if configured for that).