### PR TITLE
Add the emailkey property to global.conf

### DIFF
--- a/services/Zenoss.cse/service.json
+++ b/services/Zenoss.cse/service.json
@@ -33,6 +33,7 @@
         "global.conf.amqpusessl": "0",
         "global.conf.amqpvhost": "/zenoss",
         "global.conf.auth0-audience": "https://dev.zing.ninja",
+        "global.conf.auth0-emailkey": "https://dev.zing.ninja/email",
         "global.conf.auth0-tenant": "https://zenoss-dev.auth0.com/",
         "global.conf.auth0-tenantkey": "https://dev.zing.ninja/tenant",
         "global.conf.auth0-whitelist": "alphacorp",


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-30248

Add the emailkey property to global.conf.  We'll use this to try to parse out the email address from the access token (for db connections).