### PR TITLE
ZEN-29878: add log config file and set solr log level to WARN

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
+++ b/services/Zenoss.core.full/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
@@ -1,0 +1,30 @@
+# Default Solr log4j config
+# rootLogger log level may be programmatically overridden by -Dsolr.log.level
+solr.log=${solr.log.dir}
+log4j.rootLogger=INFO, file, CONSOLE
+
+# Console appender will be programmatically disabled when Solr is started with option -Dsolr.log.muteconsole
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+#- size rotation with log cleanup.
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=4MB
+log4j.appender.file.MaxBackupIndex=9
+
+#- File to log to and log format
+log4j.appender.file.File=${solr.log}/solr.log
+log4j.appender.file.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+# Adjust logging levels that should differ from root logger
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.solr=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.server.Server=INFO
+log4j.logger.org.eclipse.jetty.server.ServerConnector=INFO
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/services/Zenoss.core.full/Infrastructure/Solr/service.json
+++ b/services/Zenoss.core.full/Infrastructure/Solr/service.json
@@ -21,6 +21,11 @@
             "Filename": "/opt/solr/zenoss/etc/supervisor.conf",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/var/solr/log4j.properties": {
+            "Filename": "/var/solr/log4j.properties",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",

--- a/services/Zenoss.core/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
+++ b/services/Zenoss.core/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
@@ -1,0 +1,30 @@
+# Default Solr log4j config
+# rootLogger log level may be programmatically overridden by -Dsolr.log.level
+solr.log=${solr.log.dir}
+log4j.rootLogger=INFO, file, CONSOLE
+
+# Console appender will be programmatically disabled when Solr is started with option -Dsolr.log.muteconsole
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+#- size rotation with log cleanup.
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=4MB
+log4j.appender.file.MaxBackupIndex=9
+
+#- File to log to and log format
+log4j.appender.file.File=${solr.log}/solr.log
+log4j.appender.file.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+# Adjust logging levels that should differ from root logger
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.solr=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.server.Server=INFO
+log4j.logger.org.eclipse.jetty.server.ServerConnector=INFO
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/services/Zenoss.core/Infrastructure/Solr/service.json
+++ b/services/Zenoss.core/Infrastructure/Solr/service.json
@@ -21,6 +21,11 @@
             "Filename": "/opt/solr/zenoss/etc/supervisor.conf",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/var/solr/log4j.properties": {
+            "Filename": "/var/solr/log4j.properties",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",

--- a/services/Zenoss.cse/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
+++ b/services/Zenoss.cse/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
@@ -1,0 +1,31 @@
+# Default Solr log4j config
+# rootLogger log level may be programmatically overridden by -Dsolr.log.level
+solr.log=${solr.log.dir}
+log4j.rootLogger=INFO, file, CONSOLE
+
+# Console appender will be programmatically disabled when Solr is started with option -Dsolr.log.muteconsole
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+#- size rotation with log cleanup.
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=4MB
+log4j.appender.file.MaxBackupIndex=9
+
+#- File to log to and log format
+log4j.appender.file.File=${solr.log}/solr.log
+log4j.appender.file.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+# Adjust logging levels that should differ from root logger
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.solr=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.server.Server=INFO
+log4j.logger.org.eclipse.jetty.server.ServerConnector=INFO
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF
+

--- a/services/Zenoss.cse/Infrastructure/Solr/service.json
+++ b/services/Zenoss.cse/Infrastructure/Solr/service.json
@@ -21,6 +21,11 @@
             "Filename": "/opt/solr/zenoss/etc/supervisor.conf",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/var/solr/log4j.properties": {
+            "Filename": "/var/solr/log4j.properties",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",

--- a/services/Zenoss.resmgr.lite/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
+++ b/services/Zenoss.resmgr.lite/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
@@ -1,0 +1,30 @@
+# Default Solr log4j config
+# rootLogger log level may be programmatically overridden by -Dsolr.log.level
+solr.log=${solr.log.dir}
+log4j.rootLogger=INFO, file, CONSOLE
+
+# Console appender will be programmatically disabled when Solr is started with option -Dsolr.log.muteconsole
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+#- size rotation with log cleanup.
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=4MB
+log4j.appender.file.MaxBackupIndex=9
+
+#- File to log to and log format
+log4j.appender.file.File=${solr.log}/solr.log
+log4j.appender.file.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+# Adjust logging levels that should differ from root logger
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.solr=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.server.Server=INFO
+log4j.logger.org.eclipse.jetty.server.ServerConnector=INFO
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/services/Zenoss.resmgr.lite/Infrastructure/Solr/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/Solr/service.json
@@ -21,6 +21,11 @@
             "Filename": "/opt/solr/zenoss/etc/supervisor.conf",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/var/solr/log4j.properties": {
+            "Filename": "/var/solr/log4j.properties",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",

--- a/services/Zenoss.resmgr/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
+++ b/services/Zenoss.resmgr/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
@@ -1,0 +1,30 @@
+# Default Solr log4j config
+# rootLogger log level may be programmatically overridden by -Dsolr.log.level
+solr.log=${solr.log.dir}
+log4j.rootLogger=INFO, file, CONSOLE
+
+# Console appender will be programmatically disabled when Solr is started with option -Dsolr.log.muteconsole
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+#- size rotation with log cleanup.
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=4MB
+log4j.appender.file.MaxBackupIndex=9
+
+#- File to log to and log format
+log4j.appender.file.File=${solr.log}/solr.log
+log4j.appender.file.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+# Adjust logging levels that should differ from root logger
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.solr=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.server.Server=INFO
+log4j.logger.org.eclipse.jetty.server.ServerConnector=INFO
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/services/Zenoss.resmgr/Infrastructure/Solr/service.json
+++ b/services/Zenoss.resmgr/Infrastructure/Solr/service.json
@@ -21,6 +21,11 @@
             "Filename": "/opt/solr/zenoss/etc/supervisor.conf",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/var/solr/log4j.properties": {
+            "Filename": "/var/solr/log4j.properties",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",

--- a/services/ucspm.lite/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
+++ b/services/ucspm.lite/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
@@ -1,0 +1,30 @@
+# Default Solr log4j config
+# rootLogger log level may be programmatically overridden by -Dsolr.log.level
+solr.log=${solr.log.dir}
+log4j.rootLogger=INFO, file, CONSOLE
+
+# Console appender will be programmatically disabled when Solr is started with option -Dsolr.log.muteconsole
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+#- size rotation with log cleanup.
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=4MB
+log4j.appender.file.MaxBackupIndex=9
+
+#- File to log to and log format
+log4j.appender.file.File=${solr.log}/solr.log
+log4j.appender.file.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+# Adjust logging levels that should differ from root logger
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.solr=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.server.Server=INFO
+log4j.logger.org.eclipse.jetty.server.ServerConnector=INFO
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/services/ucspm.lite/Infrastructure/Solr/service.json
+++ b/services/ucspm.lite/Infrastructure/Solr/service.json
@@ -21,6 +21,11 @@
             "Filename": "/opt/solr/zenoss/etc/supervisor.conf",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/var/solr/log4j.properties": {
+            "Filename": "/var/solr/log4j.properties",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",

--- a/services/ucspm/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
+++ b/services/ucspm/Infrastructure/Solr/-CONFIGS-/var/solr/log4j.properties
@@ -1,0 +1,30 @@
+# Default Solr log4j config
+# rootLogger log level may be programmatically overridden by -Dsolr.log.level
+solr.log=${solr.log.dir}
+log4j.rootLogger=INFO, file, CONSOLE
+
+# Console appender will be programmatically disabled when Solr is started with option -Dsolr.log.muteconsole
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+#- size rotation with log cleanup.
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.MaxFileSize=4MB
+log4j.appender.file.MaxBackupIndex=9
+
+#- File to log to and log format
+log4j.appender.file.File=${solr.log}/solr.log
+log4j.appender.file.layout=org.apache.log4j.EnhancedPatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p (%t) [%X{collection} %X{shard} %X{replica} %X{core}] %c{1.} %m%n
+
+# Adjust logging levels that should differ from root logger
+log4j.logger.org.apache.zookeeper=WARN
+log4j.logger.org.apache.hadoop=WARN
+log4j.logger.org.apache.solr=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.eclipse.jetty.server.Server=INFO
+log4j.logger.org.eclipse.jetty.server.ServerConnector=INFO
+
+# set to INFO to enable infostream log messages
+log4j.logger.org.apache.solr.update.LoggingInfoStream=OFF

--- a/services/ucspm/Infrastructure/Solr/service.json
+++ b/services/ucspm/Infrastructure/Solr/service.json
@@ -21,6 +21,11 @@
             "Filename": "/opt/solr/zenoss/etc/supervisor.conf",
             "Owner": "root:root",
             "Permissions": "0664"
+        },
+        "/var/solr/log4j.properties": {
+            "Filename": "/var/solr/log4j.properties",
+            "Owner": "root:root",
+            "Permissions": "0664"
         }
     },
     "Description": "Solr Cloud",


### PR DESCRIPTION
Solr logs was filling logstash up at a rate so fast that it would
have filled up isvcs before the next purge cycle.
Set solr log level to WARN to reduce number of logs.

[JIRA](https://jira.zenoss.com/browse/ZEN-29878)