### PR TITLE
Disable basic auth on the GLB; disable login page

### DIFF
--- a/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-disable-basic-auth.conf
+++ b/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-disable-basic-auth.conf
@@ -1,0 +1,11 @@
+# ZEN-30567: disallow basic auth on the glb
+set $auth_flags "";
+if ($http_via ~ 'google') {
+    set $auth_flags "${auth_flags}1";
+}
+if ($http_authorization ~ '(?i)^basic') {
+    set $auth_flags "${auth_flags}1";
+}
+if ($auth_flags = 11) {
+    return 403;
+}

--- a/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -142,6 +142,8 @@ http {
         include zope-static.conf;
 
         location / {
+            # ZEN-30567: disallow basic auth on the glb
+            include zproxy-disable-basic-auth.conf;
 
             proxy_pass http://$whichzopes;
             proxy_set_header Host $myhost;
@@ -156,18 +158,26 @@ http {
             sub_filter_types *;
         }
 
+        location ~* ^/zport/acl_users/cookieAuthHelper/login {
+            # ZEN-30567: Disallow the basic auth login page.
+            return 403;
+        }
+
         location ~* ^/zport/dmd/reports {
-                    proxy_pass http://zopereports;
-                    proxy_set_header Host $myhost;
-                    proxy_http_version 1.1;
-                    add_header X-Frame-Options SAMEORIGIN;
-                    add_header X-XSS-Protection "1; mode=block";
-                    sub_filter "/zport/" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/zport/";
-                    sub_filter "/++" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/++";
-                    sub_filter "/static/" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/static/";
-                    sub_filter_once off;
-                    sub_filter_types *;
-                }
+            # ZEN-30567: disallow basic auth on the glb
+            include zproxy-disable-basic-auth.conf;
+
+            proxy_pass http://zopereports;
+            proxy_set_header Host $myhost;
+            proxy_http_version 1.1;
+            add_header X-Frame-Options SAMEORIGIN;
+            add_header X-XSS-Protection "1; mode=block";
+            sub_filter "/zport/" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/zport/";
+            sub_filter "/++" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/++";
+            sub_filter "/static/" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/static/";
+            sub_filter_once off;
+            sub_filter_types *;
+        }
 
         location ^~ /ping/ {
             include zenoss-zapp-ping-nginx.cfg;


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-30567

Prevent using basic authentication from the GLB.  Basic auth from an internal call will still work as expected.  We also deny access to the login page so you can't login with basic auth, bypassing
Auth0.