### PR TITLE
ZEN-29393: increase RAMCommitment for zenhub

### DIFF
--- a/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/service.json
@@ -153,7 +153,7 @@
             "Script": "curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"
         }
     ],
-    "RAMCommitment": "1G",
+    "RAMCommitment": "2G",
     "Services": [],
     "StartLevel": 2,
     "Tags": [

--- a/services/Zenoss.cse/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.cse/Zenoss/Collection/localhost/zenhub/service.json
@@ -219,7 +219,7 @@
             "Script": "curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"
         }
     ],
-    "RAMCommitment": "1G",
+    "RAMCommitment": "2G",
     "Services": [],
     "StartLevel": 2,
     "Tags": [

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/service.json
@@ -219,7 +219,7 @@
             "Script": "curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"
         }
     ],
-    "RAMCommitment": "1G",
+    "RAMCommitment": "2G",
     "Services": [],
     "StartLevel": 2,
     "Tags": [

--- a/services/ucspm/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/ucspm/Zenoss/Collection/localhost/zenhub/service.json
@@ -216,7 +216,7 @@
             "Script": "curl -A 'Solr answering prereq' -s http://localhost:8983/solr/zenoss_model/admin/ping?wt=json | grep -q '\"status\":\"OK\"'"
         }
     ],
-    "RAMCommitment": "1G",
+    "RAMCommitment": "2G",
     "Services": [],
     "StartLevel": 2,
     "Tags": [


### PR DESCRIPTION
From the start zenhub consuming more than 1GB of RAM
that is why we increase RAMCommitment to 2GB

[JIRA&INFO](https://jira.zenoss.com/browse/ZEN-29393?focusedCommentId=130995&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-130995)