### PR TITLE
Disable basic auth on GLB for api calls

### DIFF
--- a/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -205,6 +205,8 @@ http {
 
         # /api is for zapp rest APIs
         location ^~ /api/ {
+            # ZEN-30731: Block basic auth through the GLB
+            include zproxy-disable-basic-auth.conf;
             # Zapps do their own auth validation
             include zenoss-zapp-nginx.cfg;
             proxy_set_header Host $myhost;


### PR DESCRIPTION
https://jira.zenoss.com/browse/ZEN-30731

Performance metrics were able to use basic auth through the GLB.  Block all api calls through the GLB using basic authentication.