### PR TITLE
ZEN-29781: Use the new serviced to compile services. Port from CC-3559.

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -122,7 +122,7 @@ mrclean: clean
 #       by git SHA, but starting with CC 1.1.4 and RM 5.1.3, the naming convention
 #       for the tgz artifacts was updated to use CC version and build number.
 ZENPIPPKGSURL = http://zenpip.zenoss.eng/packages
-SERVICED_ARCHIVE=serviced-1.4.0-0.0.39.unstable.tgz
+SERVICED_ARCHIVE=serviced-1.6.2-0.0.297.unstable.tgz
 serviced:
 	echo " extracting: $@"
 	curl -s $(ZENPIPPKGSURL)/$(SERVICED_ARCHIVE) | \


### PR DESCRIPTION
port from https://github.com/zenoss/zenoss-service/pull/565