### PR TITLE
Feature/bump version

### DIFF
--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@
 # VERSION is the full Zenoss version; e.g., 5.0.0
 # SHORT_VERSION is the two-digit Zenoss version; e.g., 5.0
 # Note: these values are set in the build jobs, so the defaults =? aren't going to be used.
-VERSION         ?= 7.0.5
+VERSION         ?= 7.0.6
 SHORT_VERSION   ?= 7.0
 
 # These three xyz_VERSION variables define the corresponding docker image versions


### PR DESCRIPTION
ZING-1176

Bump version of develop after releasing 7.0.5. Note: these versions are provided from Jenkins, so the default here isn't used.