### PR TITLE
Use ubuntu:xenial as base for Docker image.

### DIFF
--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial
 MAINTAINER Zenoss, Inc <dev@zenoss.com>	
 
 # build dependencies


### PR DESCRIPTION
Fixes ZEN-29781.