### PR TITLE
Increase Zauth instance count to 2.

### DIFF
--- a/services/Zenoss.core.full/Zenoss/User Interface/Zauth/service.json
+++ b/services/Zenoss.core.full/Zenoss/User Interface/Zauth/service.json
@@ -110,6 +110,7 @@
     },
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
+        "default": 2,
         "min": 1
     },
     "Launch": "auto",

--- a/services/Zenoss.resmgr/Zenoss/User Interface/Zauth/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/Zauth/service.json
@@ -110,6 +110,7 @@
     },
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
+        "default": 2,
         "min": 1
     },
     "Launch": "auto",

--- a/services/ucspm/Zenoss/User Interface/Zauth/service.json
+++ b/services/ucspm/Zenoss/User Interface/Zauth/service.json
@@ -110,6 +110,7 @@
     },
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
+        "default": 2,
         "min": 1
     },
     "Launch": "auto",


### PR DESCRIPTION
Fixes ZEN-30871.

Note: the ucspm.lite, Zenoss.resmgr.lite, and Zenoss.core application templates do not have a Zauth service.