### PR TITLE
Set HostPolicy to PREFER_SEPARATE.

### DIFF
--- a/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhub/service.json
@@ -123,6 +123,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "max": 1,

--- a/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhubworker/service.json
+++ b/services/Zenoss.core.full/Zenoss/Collection/localhost/zenhubworker/service.json
@@ -122,6 +122,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "Default": 2,

--- a/services/Zenoss.core.full/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.core.full/Zenoss/Events/zeneventd/service.json
@@ -89,6 +89,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zeneventd/stable_workers"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/Zenoss.core.full/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.core.full/Zenoss/User Interface/Zope/service.json
@@ -203,6 +203,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 2

--- a/services/Zenoss.core/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.core/Zenoss/Collection/localhost/zenhub/service.json
@@ -119,6 +119,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "Max": 1,

--- a/services/Zenoss.core/Zenoss/Collection/localhost/zenhubworker/service.json
+++ b/services/Zenoss.core/Zenoss/Collection/localhost/zenhubworker/service.json
@@ -122,6 +122,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "Default": 2,

--- a/services/Zenoss.core/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.core/Zenoss/Events/zeneventd/service.json
@@ -85,6 +85,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zeneventd/stable_workers"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/Zenoss.core/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.core/Zenoss/User Interface/Zope/service.json
@@ -203,6 +203,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhub/service.json
@@ -112,6 +112,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "max": 1,

--- a/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhubworker/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Collection/localhost/zenhubworker/service.json
@@ -122,6 +122,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "Default": 2,

--- a/services/Zenoss.resmgr.lite/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/Events/zeneventd/service.json
@@ -78,6 +78,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zeneventd/stable_workers"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/Zenoss.resmgr.lite/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.resmgr.lite/Zenoss/User Interface/Zope/service.json
@@ -210,6 +210,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhub/service.json
@@ -123,6 +123,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "max": 1,

--- a/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhubworker/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Collection/localhost/zenhubworker/service.json
@@ -122,6 +122,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "Default": 2,

--- a/services/Zenoss.resmgr/Zenoss/Events/zeneventd/service.json
+++ b/services/Zenoss.resmgr/Zenoss/Events/zeneventd/service.json
@@ -89,6 +89,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zeneventd/stable_workers"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/Zenoss.resmgr/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.resmgr/Zenoss/User Interface/Zope/service.json
@@ -203,6 +203,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "default": 6,

--- a/services/ucspm.lite/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/ucspm.lite/Zenoss/Collection/localhost/zenhub/service.json
@@ -112,6 +112,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "max": 1,

--- a/services/ucspm.lite/Zenoss/Collection/localhost/zenhubworker/service.json
+++ b/services/ucspm.lite/Zenoss/Collection/localhost/zenhubworker/service.json
@@ -122,6 +122,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "Default": 2,

--- a/services/ucspm.lite/Zenoss/Events/zeneventd/service.json
+++ b/services/ucspm.lite/Zenoss/Events/zeneventd/service.json
@@ -78,6 +78,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zeneventd/stable_workers"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/ucspm.lite/Zenoss/User Interface/Zope/service.json
+++ b/services/ucspm.lite/Zenoss/User Interface/Zope/service.json
@@ -210,6 +210,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/ucspm/Zenoss/Collection/localhost/zenhub/service.json
+++ b/services/ucspm/Zenoss/Collection/localhost/zenhub/service.json
@@ -123,6 +123,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "max": 1,

--- a/services/ucspm/Zenoss/Collection/localhost/zenhubworker/service.json
+++ b/services/ucspm/Zenoss/Collection/localhost/zenhubworker/service.json
@@ -122,6 +122,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "Default": 2,

--- a/services/ucspm/Zenoss/Events/zeneventd/service.json
+++ b/services/ucspm/Zenoss/Events/zeneventd/service.json
@@ -89,6 +89,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zeneventd/stable_workers"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "min": 1

--- a/services/ucspm/Zenoss/User Interface/Zope/service.json
+++ b/services/ucspm/Zenoss/User Interface/Zope/service.json
@@ -203,6 +203,7 @@
             "Script": "/opt/zenoss/bin/healthchecks/zep_answering"
         }
     },
+    "HostPolicy": "PREFER_SEPARATE",
     "ImageID": "zenoss/zenoss5x",
     "Instances": {
         "default": 6,


### PR DESCRIPTION
Services getting a PREFER_SEPARATE HostPolicy are zenhub, zenhubworker, zeneventd, and Zope.

Fixes ZEN-22178.