### PR TITLE
ZING-1650  The service def build for api-key-proxy is using the wrong image tag 

### DIFF
--- a/makefile
+++ b/makefile
@@ -254,6 +254,7 @@ docker_svcdef-%: docker_buildimage $(OUTPUT)
 			IMAGE_NUMBER=$(IMAGE_NUMBER) \
 			MILESTONE=$(MILESTONE) \
 			RELEASE_PHASE=$(RELEASE_PHASE) \
+			zing_api_proxy_VERSION=$(zing_api_proxy_VERSION) \
 			svcdef-$*"'
 
 clean:


### PR DESCRIPTION
According to the ticket https://jira.zenoss.com/browse/ZING-1650 I added the string to the makefile