### PR TITLE
ZING-1646: add additional security headers to nginx config

### DIFF
--- a/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core.full/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -111,6 +111,9 @@ http {
             proxy_http_version 1.1;
             add_header X-Frame-Options SAMEORIGIN;
             add_header X-XSS-Protection "1; mode=block";
+            add_header Referrer-Policy "no-referrer-when-downgrade";
+            add_header X-Content-Type-Options "nosniff always";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         }
 
         location ^~ /ping/ {

--- a/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.core/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -105,6 +105,9 @@ http {
             proxy_http_version 1.1;
             add_header X-Frame-Options SAMEORIGIN;
             add_header X-XSS-Protection "1; mode=block";
+            add_header Referrer-Policy "no-referrer-when-downgrade";
+            add_header X-Content-Type-Options "nosniff always";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         }
 
         location ^~ /ping/ {

--- a/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.cse/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -150,6 +150,9 @@ http {
             proxy_http_version 1.1;
             add_header X-Frame-Options SAMEORIGIN;
             add_header X-XSS-Protection "1; mode=block";
+            add_header Referrer-Policy "no-referrer-when-downgrade";
+            add_header X-Content-Type-Options "nosniff always";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
 
             sub_filter "/zport/" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/zport/";
             sub_filter "/++" "{{or (getContext . "global.conf.cse-virtualroot") ""}}/++";

--- a/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr.lite/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -107,6 +107,9 @@ http {
             proxy_http_version 1.1;
             add_header X-Frame-Options SAMEORIGIN;
             add_header X-XSS-Protection "1; mode=block";
+            add_header Referrer-Policy "no-referrer-when-downgrade";
+            add_header X-Content-Type-Options "nosniff always";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         }
 
         location ^~ /ping/ {

--- a/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
+++ b/services/Zenoss.resmgr/-CONFIGS-/opt/zenoss/zproxy/conf/zproxy-nginx.conf
@@ -137,6 +137,9 @@ http {
             proxy_http_version 1.1;
             add_header X-Frame-Options SAMEORIGIN;
             add_header X-XSS-Protection "1; mode=block";
+            add_header Referrer-Policy "no-referrer-when-downgrade";
+            add_header X-Content-Type-Options "nosniff always";
+            add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         }
 
         include zopereports-proxy.conf;


### PR DESCRIPTION
These headers were added to increase the security level.
What is every header for:
**_Referrer-Policy "no-referrer-when-downgrade":_** the destination site won't receive information about the origin the user came from when user will go from https to HTTP. We do not need to block this completely since we do not have sensitive information in URL.
**_X-Content-Type-Options "nosniff always":_** this will prevent the browser from doing MIME-sniffing and then inserting insecure plain/text into the page as an HTML.
**_Strict-Transport-Security "max-age=31536000; includeSubdomains":_** this will force the UI to connect with a server only throught the HTTPS

[JIRA&DEMO](https://jira.zenoss.com/browse/ZING-1646)