### PR TITLE
ZEN-31872 disable OOMKiller on Databases

### DIFF
--- a/pkg/makefile
+++ b/pkg/makefile
@@ -122,7 +122,7 @@ mrclean: clean
 #       by git SHA, but starting with CC 1.1.4 and RM 5.1.3, the naming convention
 #       for the tgz artifacts was updated to use CC version and build number.
 ZENPIPPKGSURL = http://zenpip.zenoss.eng/packages
-SERVICED_ARCHIVE=serviced-1.6.2-0.0.297.unstable.tgz
+SERVICED_ARCHIVE=serviced-1.6.5-0.0.358.unstable.tgz
 serviced:
 	echo " extracting: $@"
 	curl -s $(ZENPIPPKGSURL)/$(SERVICED_ARCHIVE) | \

--- a/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/HMaster/service.json
@@ -229,6 +229,8 @@
         ]
     },
     "Name": "HMaster",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [
         {
             "Name": "All ZooKeepers up",

--- a/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/RegionServer/service.json
@@ -326,6 +326,8 @@
         ]
     },
     "Name": "RegionServer",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",

--- a/services/Zenoss.core.full/Infrastructure/HBase/ZooKeeper/service.json
+++ b/services/Zenoss.core.full/Infrastructure/HBase/ZooKeeper/service.json
@@ -85,6 +85,8 @@
         }
     ],
     "Name": "ZooKeeper",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Privileged": true,
     "RAMCommitment": "1G",
     "StartLevel": 1,

--- a/services/Zenoss.core.full/Infrastructure/Solr/service.json
+++ b/services/Zenoss.core.full/Infrastructure/Solr/service.json
@@ -76,6 +76,8 @@
         }
     ],
     "Name": "Solr",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "RAMCommitment": "1G",
     "StartLevel": 1,

--- a/services/Zenoss.core.full/Infrastructure/mariadb/service.json
+++ b/services/Zenoss.core.full/Infrastructure/mariadb/service.json
@@ -34,6 +34,8 @@
         }
     ],
     "Name": "mariadb",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "1G",
     "Snapshot": {

--- a/services/Zenoss.core.full/Infrastructure/redis/service.json
+++ b/services/Zenoss.core.full/Infrastructure/redis/service.json
@@ -33,6 +33,8 @@
         }
     ],
     "Name": "redis",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "RAMCommitment": "1G",
     "StartLevel": 1,
     "Tags": [

--- a/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/HMaster/service.json
@@ -229,6 +229,8 @@
         ]
     },
     "Name": "HMaster",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [
         {
             "Name": "All ZooKeepers up",

--- a/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/RegionServer/service.json
@@ -326,6 +326,8 @@
         ]
     },
     "Name": "RegionServer",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",

--- a/services/Zenoss.core/Infrastructure/HBase/ZooKeeper/service.json
+++ b/services/Zenoss.core/Infrastructure/HBase/ZooKeeper/service.json
@@ -86,6 +86,8 @@
         }
     ],
     "Name": "ZooKeeper",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Privileged": true,
     "RAMCommitment": "256M",
     "StartLevel": 1,

--- a/services/Zenoss.core/Infrastructure/Solr/service.json
+++ b/services/Zenoss.core/Infrastructure/Solr/service.json
@@ -76,6 +76,8 @@
         }
     ],
     "Name": "Solr",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "RAMCommitment": "1G",
     "StartLevel": 1,

--- a/services/Zenoss.core/Infrastructure/mariadb/service.json
+++ b/services/Zenoss.core/Infrastructure/mariadb/service.json
@@ -34,6 +34,8 @@
         }
     ],
     "Name": "mariadb",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "1G",
     "Snapshot": {

--- a/services/Zenoss.core/Infrastructure/redis/service.json
+++ b/services/Zenoss.core/Infrastructure/redis/service.json
@@ -80,6 +80,8 @@
         ]
     },
     "Name": "redis",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "RAMCommitment": "256M",
     "StartLevel": 1,
     "Tags": [

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/HMaster/service.json
@@ -229,6 +229,8 @@
         ]
     },
     "Name": "HMaster",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [
         {
             "Name": "All ZooKeepers up",

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/RegionServer/service.json
@@ -326,6 +326,8 @@
         ]
     },
     "Name": "RegionServer",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",

--- a/services/Zenoss.resmgr.lite/Infrastructure/HBase/ZooKeeper/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/HBase/ZooKeeper/service.json
@@ -86,6 +86,8 @@
         }
     ],
     "Name": "ZooKeeper",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Privileged": true,
     "RAMCommitment": "256M",
     "StartLevel": 1,

--- a/services/Zenoss.resmgr.lite/Infrastructure/Solr/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/Solr/service.json
@@ -76,6 +76,8 @@
         }
     ],
     "Name": "Solr",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "RAMCommitment": "1G",
     "StartLevel": 1,

--- a/services/Zenoss.resmgr.lite/Infrastructure/mariadb-events/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/mariadb-events/service.json
@@ -34,6 +34,8 @@
         }
     ],
     "Name": "mariadb-events",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "2G",
     "Snapshot": {

--- a/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/service.json
@@ -35,6 +35,8 @@
         }
     ],
     "Name": "mariadb-model",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "4G",
     "Snapshot": {

--- a/services/Zenoss.resmgr.lite/Infrastructure/redis/service.json
+++ b/services/Zenoss.resmgr.lite/Infrastructure/redis/service.json
@@ -80,6 +80,8 @@
         ]
     },
     "Name": "redis",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "RAMCommitment": "256M",
     "StartLevel": 1,
     "Tags": [

--- a/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/HMaster/service.json
@@ -229,6 +229,8 @@
         ]
     },
     "Name": "HMaster",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [
         {
             "Name": "All ZooKeepers up",

--- a/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/RegionServer/service.json
@@ -326,6 +326,8 @@
         ]
     },
     "Name": "RegionServer",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",

--- a/services/ucspm.lite/Infrastructure/HBase/ZooKeeper/service.json
+++ b/services/ucspm.lite/Infrastructure/HBase/ZooKeeper/service.json
@@ -86,6 +86,8 @@
         }
     ],
     "Name": "ZooKeeper",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Privileged": true,
     "RAMCommitment": "256M",
     "StartLevel": 1,

--- a/services/ucspm.lite/Infrastructure/Solr/service.json
+++ b/services/ucspm.lite/Infrastructure/Solr/service.json
@@ -76,6 +76,8 @@
         }
     ],
     "Name": "Solr",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "RAMCommitment": "1G",
     "StartLevel": 1,

--- a/services/ucspm.lite/Infrastructure/mariadb-events/service.json
+++ b/services/ucspm.lite/Infrastructure/mariadb-events/service.json
@@ -34,6 +34,8 @@
         }
     ],
     "Name": "mariadb-events",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "2G",
     "Snapshot": {

--- a/services/ucspm.lite/Infrastructure/mariadb-model/service.json
+++ b/services/ucspm.lite/Infrastructure/mariadb-model/service.json
@@ -35,6 +35,8 @@
         }
     ],
     "Name": "mariadb-model",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "4G",
     "Snapshot": {

--- a/services/ucspm.lite/Infrastructure/redis/service.json
+++ b/services/ucspm.lite/Infrastructure/redis/service.json
@@ -80,6 +80,8 @@
         ]
     },
     "Name": "redis",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "RAMCommitment": "256M",
     "StartLevel": 1,
     "Tags": [

--- a/services/ucspm/Infrastructure/HBase/HMaster/service.json
+++ b/services/ucspm/Infrastructure/HBase/HMaster/service.json
@@ -229,6 +229,8 @@
         ]
     },
     "Name": "HMaster",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [
         {
             "Name": "All ZooKeepers up",

--- a/services/ucspm/Infrastructure/HBase/RegionServer/service.json
+++ b/services/ucspm/Infrastructure/HBase/RegionServer/service.json
@@ -326,6 +326,8 @@
         ]
     },
     "Name": "RegionServer",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "Privileged": true,
     "RAMCommitment": "1G",

--- a/services/ucspm/Infrastructure/HBase/ZooKeeper/service.json
+++ b/services/ucspm/Infrastructure/HBase/ZooKeeper/service.json
@@ -85,6 +85,8 @@
         }
     ],
     "Name": "ZooKeeper",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Privileged": true,
     "RAMCommitment": "1G",
     "StartLevel": 1,

--- a/services/ucspm/Infrastructure/Solr/service.json
+++ b/services/ucspm/Infrastructure/Solr/service.json
@@ -76,6 +76,8 @@
         }
     ],
     "Name": "Solr",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "Prereqs": [],
     "RAMCommitment": "1G",
     "StartLevel": 1,

--- a/services/ucspm/Infrastructure/mariadb-events/service.json
+++ b/services/ucspm/Infrastructure/mariadb-events/service.json
@@ -34,6 +34,8 @@
         }
     ],
     "Name": "mariadb-events",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "2G",
     "Snapshot": {

--- a/services/ucspm/Infrastructure/mariadb-model/service.json
+++ b/services/ucspm/Infrastructure/mariadb-model/service.json
@@ -35,6 +35,8 @@
         }
     ],
     "Name": "mariadb-model",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "4G",
     "Snapshot": {

--- a/services/ucspm/Infrastructure/redis/service.json
+++ b/services/ucspm/Infrastructure/redis/service.json
@@ -80,6 +80,8 @@
         ]
     },
     "Name": "redis",
+    "OomKillDisable": true,
+    "OomScoreAdj": 0,
     "RAMCommitment": "1G",
     "StartLevel": 1,
     "Tags": [


### PR DESCRIPTION
Updated serviced to compile services because of new parameters in the service definition that we started support from CC 1.6.5