### PR TITLE
ZEN-32033: Zope, Zauth, zenreports, zenapi don't pass healthchecks as…

### DIFF
--- a/services/Zenoss.cse/Zenoss/User Interface/Zauth/service.json
+++ b/services/Zenoss.cse/Zenoss/User Interface/Zauth/service.json
@@ -76,8 +76,8 @@
             "Script": "curl -A 'zauth answering healthcheck' -s http://localhost:9180/zport/ruok | grep -q imok"
         },
         "deadlock_check": {
-            "Interval": 30.0,
-            "KillCountLimit": 3,
+            "Interval": 60.0,
+            "KillCountLimit": 5,
             "KillExitCodes": [
                 28
             ],

--- a/services/Zenoss.cse/Zenoss/User Interface/Zope/service.json
+++ b/services/Zenoss.cse/Zenoss/User Interface/Zope/service.json
@@ -177,8 +177,8 @@
             "Script": "curl -A 'Zope answering healthcheck' --retry 3 --max-time 2 -s http://localhost:9080/zport/ruok | grep -q imok"
         },
         "deadlock_check": {
-            "Interval": 30.0,
-            "KillCountLimit": 3,
+            "Interval": 60.0,
+            "KillCountLimit": 5,
             "KillExitCodes": [
                 28
             ],

--- a/services/Zenoss.cse/Zenoss/User Interface/zenapi/service.json
+++ b/services/Zenoss.cse/Zenoss/User Interface/zenapi/service.json
@@ -120,8 +120,8 @@
             "Script": "curl -A 'zenapi answering healthcheck' --retry 3 --max-time 2 -s http://localhost:9320/zport/ruok | grep -q imok"
         },
         "deadlock_check": {
-            "Interval": 30.0,
-            "KillCountLimit": 3,
+            "Interval": 60.0,
+            "KillCountLimit": 5,
             "KillExitCodes": [
                 28
             ],

--- a/services/Zenoss.cse/Zenoss/User Interface/zendebug/service.json
+++ b/services/Zenoss.cse/Zenoss/User Interface/zendebug/service.json
@@ -177,8 +177,8 @@
             "Script": "curl -A 'zendebug answering healthcheck' --retry 3 --max-time 2 -s http://localhost:9310/zport/ruok | grep -q imok"
         },
         "deadlock_check": {
-            "Interval": 30.0,
-            "KillCountLimit": 3,
+            "Interval": 60.0,
+            "KillCountLimit": 5,
             "KillExitCodes": [
                 28
             ],

--- a/services/Zenoss.cse/Zenoss/User Interface/zenreports/service.json
+++ b/services/Zenoss.cse/Zenoss/User Interface/zenreports/service.json
@@ -106,8 +106,8 @@
             "Script": "curl -A 'zenreports answering healthcheck' --retry 3 --max-time 2 -s http://localhost:9290/zport/ruok | grep -q imok"
         },
         "deadlock_check": {
-            "Interval": 30.0,
-            "KillCountLimit": 3,
+            "Interval": 60.0,
+            "KillCountLimit": 5,
             "KillExitCodes": [
                 28
             ],


### PR DESCRIPTION
… quickly as they used to