### PR TITLE
Let supervisord manage mariadb directly.

### DIFF
--- a/services/Zenoss.cse/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.cse/Infrastructure/mariadb-events/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,6 +1,10 @@
 [supervisord]
 nodaemon=true
-logfile = /opt/zenoss/log/mariadb-events_supervisord.log
+user=root
+logfile=/opt/zenoss/log/{{.Name}}_supervisord.log
+redirect_stderr=true
+logfile_maxbytes=10MB
+logfile_backups=5
 
 [unix_http_server]
 file=/tmp/supervisor.sock
@@ -12,26 +16,32 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:mariadb]
-command=/usr/bin/mysqld_safe
+command=/usr/sbin/mysqld
 autorestart=true
 autostart=true
 startsecs=5
+stopwaitsecs=30
 priority=1
+user=mysql
 
-[program:zep_metrics]
+[program:mysql_stats]
 command=/usr/bin/python /opt/zenoss/bin/metrics/mysqlstats.py -d zep
 autorestart=true
 autostart=true
 startsecs=5
+user=zenoss
+redirect_stderr=true
+stdout_logfile=/opt/zenoss/log/{{.Name}}_%(program_name)s.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=5
 
-[program:mariadb_events_metrics]
+[program:storage_stats]
 command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-events
 autorestart=true
 autostart=true
 startsecs=5
-
-; logging
+user=zenoss
 redirect_stderr=true
+stdout_logfile=/opt/zenoss/log/{{.Name}}_%(program_name)s.log
 stdout_logfile_maxbytes=10MB
-stdout_logfile_backups=10
-stdout_logfile=/opt/zenoss/log/%(program_name)s.log
+stdout_logfile_backups=5

--- a/services/Zenoss.cse/Infrastructure/mariadb-events/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.cse/Infrastructure/mariadb-events/-CONFIGS-/etc/my.cnf
@@ -6,7 +6,7 @@ innodb_file_per_table
 skip_external_locking
 skip-host-cache
 skip-name-resolve
-log_error=/var/log/mysqld.log
+log_error = /var/log/mysqld.log
 
 #
 # Per the current Zenoss Resource Manager Install Guide,

--- a/services/Zenoss.cse/Infrastructure/mariadb-events/service.json
+++ b/services/Zenoss.cse/Infrastructure/mariadb-events/service.json
@@ -52,7 +52,6 @@
     "Name": "mariadb-events",
     "OomKillDisable": true,
     "OomScoreAdj": 0,
-    "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "2G",
     "Snapshot": {
         "Pause": "PAUSE_CHECK_TIMEOUT=60 LOCK_HOLD_DURATION=600 ${ZENHOME:-/opt/zenoss}/bin/quiesce-mariadb.sh pause",

--- a/services/Zenoss.cse/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
+++ b/services/Zenoss.cse/Infrastructure/mariadb-model/-CONFIGS-/etc/mariadb/mariadb_supervisor.conf
@@ -1,6 +1,10 @@
 [supervisord]
 nodaemon=true
-logfile = /opt/zenoss/log/mariadb-model_supervisord.log
+user=root
+logfile=/opt/zenoss/log/{{.Name}}_supervisord.log
+redirect_stderr=true
+logfile_maxbytes=10MB
+logfile_backups=5
 
 [unix_http_server]
 file=/tmp/supervisor.sock
@@ -12,26 +16,32 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:mariadb]
-command=/usr/bin/mysqld_safe
+command=/usr/sbin/mysqld
 autorestart=true
 autostart=true
 startsecs=5
+stopwaitsecs=30
 priority=1
+user=mysql
 
-[program:zodb_metrics]
+[program:mysql_stats]
 command=/usr/bin/python /opt/zenoss/bin/metrics/mysqlstats.py -d zodb
 autorestart=true
 autostart=true
 startsecs=5
+user=zenoss
+redirect_stderr=true
+stdout_logfile=/opt/zenoss/log/{{.Name}}_%(program_name)s.log
+stdout_logfile_maxbytes=10MB
+stdout_logfile_backups=5
 
-[program:mariadb_model_metrics]
+[program:storage_stats]
 command=/usr/bin/python /opt/zenoss/bin/metrics/storagestats.py mariadb-model
 autorestart=true
 autostart=true
 startsecs=5
-
-; logging
+user=zenoss
 redirect_stderr=true
+stdout_logfile=/opt/zenoss/log/{{.Name}}_%(program_name)s.log
 stdout_logfile_maxbytes=10MB
-stdout_logfile_backups=10
-stdout_logfile=/opt/zenoss/log/%(program_name)s.log
+stdout_logfile_backups=5

--- a/services/Zenoss.cse/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.cse/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -6,7 +6,7 @@ innodb_file_per_table
 skip_external_locking
 skip-host-cache
 skip-name-resolve
-log_error=/var/log/mysqld.log
+log_error = /var/log/mysqld.log
 
 # Buffer pool instances should equal number of cores (subtract 1 for VMs) 
 # Buffer pool size should be at least 1G per instance per MySQL documentation 

--- a/services/Zenoss.cse/Infrastructure/mariadb-model/service.json
+++ b/services/Zenoss.cse/Infrastructure/mariadb-model/service.json
@@ -53,7 +53,6 @@
     "Name": "mariadb-model",
     "OomKillDisable": true,
     "OomScoreAdj": 0,
-    "PIDFile": "exec echo /var/lib/mysql/$(hostname).pid",
     "RAMCommitment": "4G",
     "Snapshot": {
         "Pause": "PAUSE_CHECK_TIMEOUT=60 LOCK_HOLD_DURATION=600 ${ZENHOME:-/opt/zenoss}/bin/quiesce-mariadb.sh pause",


### PR DESCRIPTION
* Replaced call to mysqld_safe with mysqld. The mysqld_safe command is a wrapper that has the same functionality as supervisord and so, in effect, is redundant.
* Added 'user' option to supervisord managed programs to control security.
* Allow more time for mariadb to shut down before supervisord kills the process.

Fixes ZEN-32261.