### PR TITLE
Add 'hub' to Tags field of hub services.

### DIFF
--- a/services/Zenoss.cse/Zenoss/Collection/localhost/zenhubiworker/service.json
+++ b/services/Zenoss.cse/Zenoss/Collection/localhost/zenhubiworker/service.json
@@ -161,7 +161,8 @@
     "Services": [],
     "StartLevel": 2,
     "Tags": [
-        "daemon"
+        "daemon",
+        "hub"
     ],
     "Volumes": [
         {

--- a/services/Zenoss.cse/Zenoss/Collection/localhost/zenhubworker (adm)/service.json
+++ b/services/Zenoss.cse/Zenoss/Collection/localhost/zenhubworker (adm)/service.json
@@ -168,7 +168,8 @@
     "Services": [],
     "StartLevel": 2,
     "Tags": [
-        "daemon"
+        "daemon",
+        "hub"
     ],
     "Volumes": [
         {

--- a/services/Zenoss.cse/Zenoss/Collection/localhost/zenhubworker (default)/service.json
+++ b/services/Zenoss.cse/Zenoss/Collection/localhost/zenhubworker (default)/service.json
@@ -168,7 +168,8 @@
     "Services": [],
     "StartLevel": 2,
     "Tags": [
-        "daemon"
+        "daemon",
+        "hub"
     ],
     "Volumes": [
         {


### PR DESCRIPTION
Fixes ZEN-32378.

This PR contains adds a "hub" tag to the hub services, i.e. the zenhubworker and zenhubiworker services.