### PR TITLE
ZEN-32689 Update 'mariadb_answering' healthcheck in zeneventserver

### DIFF
--- a/services/Zenoss.cse/Zenoss/Events/zeneventserver/service.json
+++ b/services/Zenoss.cse/Zenoss/Events/zeneventserver/service.json
@@ -88,9 +88,9 @@
             "Interval": 5.0,
             "Script": "curl -A 'zeneventserver answering healthcheck' -f -s http://localhost:8084/zeneventserver/api/1.0/heartbeats/"
         },
-        "mariadb_answering": {
+        "mariadb_events_answering": {
             "Interval": 10.0,
-            "Script": "/opt/zenoss/bin/healthchecks/mariadb_answering"
+            "Script": "su - zenoss -c '/opt/zenoss/bin/python /opt/zenoss/Products/ZenUtils/ZenDB.py --usedb zep --execsql=\";\"'"
         },
         "memcached_answering": {
             "Interval": 10.0,


### PR DESCRIPTION
This pull request replaces the name of healthcheck 'mariadb_answering' with 'mariadb_events_anwering' for clarity.
Also, the script for healthcheck was changed, it used the credentials for zodb when zeneventserver actually connects to the zep.
These changes fix the problem when healthcheck is failed after changing a password for 'zenoss' user in mariadb-events