### PR TITLE
Add service migration package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-**/output
 *~
 .idea/*

--- a/hack/Dockerfile
+++ b/hack/Dockerfile
@@ -1,7 +1,0 @@
-FROM ubuntu:xenial
-MAINTAINER Zenoss, Inc <dev@zenoss.com>	
-
-# build dependencies
-RUN	apt-get update -qq && apt-get install -y -q build-essential libtool rpm curl make autoconf ruby ruby-dev
-RUN	gem install --no-ri --no-rdoc fpm
-

--- a/image/Dockerfile.in
+++ b/image/Dockerfile.in
@@ -1,0 +1,12 @@
+FROM zenoss/zenoss-centos-base:%VERSION%.devtools
+
+RUN yum makecache && \
+	yum install -y ruby ruby-devel && \
+	yum autoremove -y && \
+	yum clean all && \
+	gem install --no-ri --no-rdoc fpm
+
+RUN pip install -U setuptools
+
+RUN groupadd --gid %GID% builder
+RUN useradd --uid %UID% --gid %GID% --comment "" builder

--- a/image/add_user.sh
+++ b/image/add_user.sh
@@ -11,5 +11,5 @@
 
 set -e
 
-adduser --shell /bin/bash --uid $1 --gecos "" --disabled-password --home /home/serviceduser serviceduser
-
+groupadd --gid $2 builder
+useradd --uid $1 --gid $2 --comment "" builder

--- a/make_template.sh
+++ b/make_template.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+if [ "$1" == "-h" ] ; then
+   echo Usage: $(basename $0) [directory]
+   echo
+   echo Create a service template from the given directory.  The result is
+   echo written to stdout. If no directory is given, the image name
+   echo substitutions are printed.
+   echo
+   echo If the following variables are not found in the environment, their
+   echo values are extracted from the version.mk file in product-assembly in
+   echo a zendev environment.  If that fails, this script exits with an error.
+   echo
+   echo "   HBASE_VERSION"
+   echo "   HDFS_VERSION"
+   echo "   OPENTSDB_VERSION"
+   echo "   OTSDB_BIGTABLE_VERSION"
+   echo
+   echo If the ZENOSS_IMAGE_TAG and MARIADB_IMAGE_TAG variables are not set,
+   echo their values are set to the name of the current zendev environment.
+   echo
+   echo If ZENOSS_IMAGE is not set, its value is set to \"zendev/devimg\"
+   echo If MARIADB_IMAGE is not set, its value is set to \"zendev/mariadb\"
+   echo
+   echo If the VERSION variable is not set, the value is read from the VERSION file.
+   echo
+   echo This script depends on the \'serviced\' command being available.
+   echo
+   exit 0
+fi
+
+zendev=$(which zendev)
+if [ $? -eq 0 ] ; then
+   zendev_root=$(${zendev} root)
+   zendev_env=$(${zendev} env)
+   version_file=${zendev_root}/src/github.com/zenoss/product-assembly/versions.mk
+   if [ ! -f ${version_file} ]; then
+      unset version_file
+   fi
+   service_version_file=${zendev_root}/src/github.com/zenoss/zenoss-service/VERSION
+   if [ ! -f ${service_version_file} ]; then
+      unset service_version_file
+   fi
+fi
+
+function get_variable() {
+   local value=${!1}
+   if [ -z ${value:+x} ] ; then
+      if [ -z ${version_file+x} ]; then
+         echo "$1 is not set and product-assembly/versions.mk not found" 1>&2
+         exit 1
+      fi
+      echo $(grep "^\<$1\>" ${version_file} | cut -f2 -d'=')
+   fi
+   echo ${value}
+}
+
+if [ -z ${VERSION:+x} ]; then
+   if [ -z ${service_version_file:+x} ]; then
+      version=$(get_variable VERSION)
+   else
+      version=$(cat ${service_version_file})
+   fi
+else
+   version=${VERSION}
+fi
+
+if [ -z ${ZENOSS_IMAGE:+x} ]; then
+   # ZENOSS_IMAGE is null or not set, assume devimg build
+   zenoss_image=zendev/devimg
+else
+   zenoss_image=${ZENOSS_IMAGE}
+fi
+
+if [ -z ${ZENOSS_IMAGE_TAG:+x} ]; then
+   # ZENOSS_IMAGE_TAG is null or not set, assume devimg build
+   zenoss_tag=${zendev_env}
+else
+   zenoss_tag=${ZENOSS_IMAGE_TAG}
+fi
+
+if [ -z ${MARIADB_IMAGE:+x} ]; then
+   # MARIADB_IMAGE is null or not set, assume devimg build
+   mariadb_image=zendev/mariadb
+else
+   mariadb_image=${MARIADB_IMAGE}
+fi
+
+if [ -z ${MARIADB_IMAGE_TAG:+x} ]; then
+   # MARIADB_IMAGE_TAG is null or not set, assume devimg build
+   mariadb_version=${zendev_env}
+else
+   mariadb_version=${MARIADB_IMAGE_TAG}
+fi
+
+hbase_version=$(get_variable HBASE_VERSION) || exit 1
+hdfs_version=$(get_variable HDFS_VERSION) || exit 1
+opentsdb_version=$(get_variable OPENTSDB_VERSION) || exit 1
+otsdb_bigtable_version=$(get_variable OTSDB_BIGTABLE_VERSION) || exit 1
+
+# Retrieve the project image name
+project_image=$(get_variable IMAGE_PROJECT)
+if [ -z ${project_image:+x} ]; then
+   # PROJECT_IMAGE is null or not set, set a default
+   project_image=zenoss
+fi
+
+if [ "$1" == "" ] ; then
+   printf "%-30s %s\n" zenoss/zenoss5x ${zenoss_image}:${zenoss_tag}
+   printf "%-30s %s\n" zenoss/mariadb:xx ${mariadb_image}:${mariadb_version}
+   printf "%-30s %s\n" zenoss/hbase:xx zenoss/hbase:${hbase_version}
+   printf "%-30s %s\n" zenoss/hdfs:xx zenoss/hbase:${hdfs_version}
+   printf "%-30s %s\n" zenoss/opentsdb:xx zenoss/opentsdb:${opentsdb_version}
+else
+
+   ss=$(which serviced)
+   if [ $? -ne 0 ] ; then
+      echo "serviced: command not found" 1>&2
+      exit 1
+   fi
+
+   sed -i -e "s/\"Version\": \".*\",/\"Version\": \"${version}\",/" $1/service.json
+   ${ss} template compile \
+      --map zenoss/zenoss5x,zendev/devimg:${zenoss_tag} \
+      --map zenoss/mariadb:xx,zendev/mariadb:${mariadb_version} \
+      --map zenoss/hbase:xx,zenoss/hbase:${hbase_version} \
+      --map zenoss/hdfs:xx,zenoss/hbase:${hdfs_version} \
+      --map zenoss/opentsdb:xx,zenoss/opentsdb:${opentsdb_version} \
+      $1
+fi

--- a/makefile
+++ b/makefile
@@ -10,25 +10,34 @@
 #        also recorded in the zenoss/product-assembly repo.
 #
 
+space := $(subst ,, )
+
+# Local environment information
+DOCKER = $(shell which docker)
+PWD    = ${CURDIR}
+UID    = $(shell id -u)
+GID    = $(shell id -g)
+
 # VERSION is the full Zenoss version; e.g., 5.0.0
 # SHORT_VERSION is the two-digit Zenoss version; e.g., 5.0
-VERSION         ?= 5.1.1
-SHORT_VERSION   ?= 5.1
+VERSION       ?= 6.5.0
+SHORT_VERSION  = $(subst $(space),.,$(wordlist 1,2,$(subst ., ,$(VERSION))))
 
 # These three xyz_VERSION variables define the corresponding docker image versions
-hbase_VERSION    ?= v16
-hdfs_VERSION     ?= v4
-opentsdb_VERSION ?= v23
+hbase_VERSION    ?= 24.0.8
+hdfs_VERSION     ?= 24.0.8
+opentsdb_VERSION ?= 24.0.8
 
-DOCKER          ?= $(shell which docker)
-BUILD_NUMBER    ?= $(shell date +%Y%m%d%H%M%S)
+# The zenoss-centos-base version to use for the service template pkg builder image.
+ZENOSS_CENTOS_BASE_VERSION ?= 1.2.28
+
 #
 # Latch in the date with an immediate assignment to avoid
 # date roll-over edge case incurred by lazy evaluation.
 #
+BUILD_NUMBER     ?= $(shell date +%Y%m%d%H%M%S)
 _BUILD_NUMBER    := $(BUILD_NUMBER)
-BUILD_IMAGE      ?= "zenoss/svcdefbuild:trusty"
-SRCROOT          ?= $(shell pwd)/src
+BUILD_IMAGE      ?= "zenoss/svcdefbuild"
 BUILD_TYPE       ?= core
 BUILD_NAME       ?= zenoss_$(BUILD_TYPE)-$(VERSION)
 PREFIX           ?= /opt/zenoss
@@ -37,8 +46,6 @@ MILESTONE        ?= unstable # unstable | testing | stable
 MILESTONE_SUFFIX  =
 RELEASE_PHASE    ?= # eg, BETA2 | ALPHA1 | CR13 | 1 | 2 | <blank>
 _RELEASE_PHASE   := $(strip $(RELEASE_PHASE))
-PWD				  = $(shell pwd)
-UID				  = $(shell id -u)
 
 # Allow milestone to influence our artifact versioning.
 BUILD_TAG      = $($(strip $(MILESTONE))_TAG)
@@ -47,7 +54,7 @@ testing_TAG    = $(VERSION)_$(_RELEASE_PHASE)
 unstable_TAG   = $(VERSION)_$(_BUILD_NUMBER)
 
 # Suck in reference to an image
-IMAGE_NUMBER        ?= ""
+IMAGE_NUMBER        ?= $(_BUILD_NUMBER)
 IMAGE_TAG            = $($(strip $(MILESTONE))_IMAGE_TAG)
 stable_IMAGE_TAG     = $(VERSION)_$(_RELEASE_PHASE)
 testing_IMAGE_TAG    = $(VERSION)_$(_RELEASE_PHASE)
@@ -56,35 +63,30 @@ unstable_IMAGE_TAG   = $(VERSION)_$(IMAGE_NUMBER)_unstable
 # Describe docker repositories where we push entitled content.
 repo_name_suffix      := _$(SHORT_VERSION)
 
-docker.io_REGPATH     =
-docker.io_USER        = zenoss
-docker.io_core_REPO   = core$(repo_name_suffix)
-docker.io_resmgr_REPO = resmgr$(repo_name_suffix)
-docker.io_ucspm_REPO  = ucspm$(repo_name_suffix)
-docker.io_cse_REPO    = cse$(repo_name_suffix)
-docker.io_SUFFIX      = $(MILESTONE_SUFFIX)
-
-docker_HOST           = docker.io
-docker_PREFIX         = $($(docker_HOST)_REGPATH)$($(docker_HOST)_USER)/
-
-#
-# docker_HOST         docker_PREFIX
-# ------------------  -------------------
-# docker.io           zenoss/
-#
+image_REGPATH     =
+image_PROJECT     = zenoss
+image_core_REPO   = core$(repo_name_suffix)
+image_resmgr_REPO = resmgr$(repo_name_suffix)
+image_ucspm_REPO  = ucspm$(repo_name_suffix)
+image_cse_REPO    = cse$(repo_name_suffix)
+image_SUFFIX      = $(MILESTONE_SUFFIX)
 
 # Mechanism for overriding ImageIDs in service definition json source:
 #
 # from: ImageID: "zenoss/zenoss5x"
 # into: ImageID: "zenoss/core_5.1:5.1.1_78_unstable"
-
+#
 jsonsrc_zenoss_ImageID = zenoss/zenoss5x
-desired_zenoss_ImageID = $(docker_PREFIX)$($(docker_HOST)_$(short_product)_REPO)$($(docker_HOST)_SUFFIX):$(IMAGE_TAG)
+desired_zenoss_ImageID = $(image_PROJECT)/$(image_$(short_product)_REPO)$(image_SUFFIX):$(IMAGE_TAG)
 svcdef_ImageID_maps   += $(jsonsrc_zenoss_ImageID),$(desired_zenoss_ImageID)
+
+#
+# from: ImageID: "zenoss/mariadb:xx"
+# into: ImageID: "zenoss/mariadb-core:5.1.1_78_unstable"
 #
 jsonsrc_mariadb_ImageID = zenoss/mariadb:xx
-desired_mariadb_ImageID = $(docker_PREFIX)mariadb-$(short_product):$(IMAGE_TAG)
-svcdef_ImageID_maps     += $(jsonsrc_mariadb_ImageID),$(desired_mariadb_ImageID)
+desired_mariadb_ImageID = $(image_PROJECT)/mariadb-$(short_product):$(IMAGE_TAG)
+svcdef_ImageID_maps    += $(jsonsrc_mariadb_ImageID),$(desired_mariadb_ImageID)
 
 #
 # Allow json to be updated automatically at build time if we switch publish
@@ -94,22 +96,18 @@ svcdef_ImageID_maps     += $(jsonsrc_mariadb_ImageID),$(desired_mariadb_ImageID)
 #     desired_<prod>_ImageID = what you want the ID to be
 #
 jsonsrc_hbase_ImageID = zenoss/hbase:xx
-desired_hbase_ImageID = $(docker_PREFIX)hbase:$(hbase_VERSION)
+desired_hbase_ImageID = $(image_PROJECT)/hbase:$(hbase_VERSION)
 svcdef_ImageID_maps  += $(jsonsrc_hbase_ImageID),$(desired_hbase_ImageID)
 #
 jsonsrc_hdfs_ImageID = zenoss/hdfs:xx
-desired_hdfs_ImageID = $(docker_PREFIX)hdfs:$(hdfs_VERSION)
-svcdef_ImageID_maps  += $(jsonsrc_hdfs_ImageID),$(desired_hdfs_ImageID)
+desired_hdfs_ImageID = $(image_PROJECT)/hdfs:$(hdfs_VERSION)
+svcdef_ImageID_maps += $(jsonsrc_hdfs_ImageID),$(desired_hdfs_ImageID)
 #
 jsonsrc_opentsdb_ImageID = zenoss/opentsdb:xx
-desired_opentsdb_ImageID = $(docker_PREFIX)opentsdb:$(opentsdb_VERSION)
+desired_opentsdb_ImageID = $(image_PROJECT)/opentsdb:$(opentsdb_VERSION)
 svcdef_ImageID_maps     += $(jsonsrc_opentsdb_ImageID),$(desired_opentsdb_ImageID)
 
-.PHONY: default docker_buildimage docker_svcdefpkg-% docker_svcdef-%
-
-
-$(SRCROOT):
-	services
+.PHONY: default docker_buildimage docker_svcdefpkg-% docker_svcdef-% migrations clean-migrations
 
 #
 # The serviced binary referenced by SVCDEF_EXE is injected into the build
@@ -172,6 +170,7 @@ zenoss-cse-$(BUILD_TAG).json_SRC_DIR := $(svcdef_SRC_DIR)/Zenoss.cse
 #
 svcdef_BUILD_DIR      = pkg/templates
 svcdef_BUILD_TARGETS := $(foreach product,$(svcdef_PRODUCTS),$(svcdef_BUILD_DIR)/$(product)-$(BUILD_TAG).json)
+
 .SECONDEXPANSION:
 $(svcdef_BUILD_TARGETS): short_product = $(patsubst zenoss-%,%,$(patsubst %-$(BUILD_TAG).json,%,$(@F)))
 $(svcdef_BUILD_TARGETS): map_opt       = $(patsubst %,-map %,$(svcdef_ImageID_maps))
@@ -229,27 +228,37 @@ svcdefpkg-%: | $(svcdef_BUILD_DIR) $(OUTPUT)
 # Dockerized targets #
 #####################
 
-docker_buildimage:
-	$(DOCKER) build -t $(BUILD_IMAGE) hack/
+image/Dockerfile: image/Dockerfile.in
+	@sed \
+		-e "s/%VERSION%/$(ZENOSS_CENTOS_BASE_VERSION)/g" \
+		-e "s/%GID%/$(GID)/g" \
+		-e "s/%UID%/$(UID)/g" \
+		$< > $@
+
+docker_buildimage: image/Dockerfile
+	@$(DOCKER) build -t $(BUILD_IMAGE) $(<D)
 
 docker_svcdefpkg-%: docker_buildimage $(OUTPUT)
-	$(DOCKER) run --rm -v $(PWD):/mnt/pwd \
+	$(DOCKER) run \
+		--rm \
+		-v $(PWD):/mnt/pwd \
 		-v $(OUTPUT):/mnt/pwd/output \
+		-e "VERSION=$(VERSION)" \
+		-e "SHORT_VERSION=$(SHORT_VERSION)" \
+		-e "hbase_VERSION=$(hbase_VERSION)" \
+		-e "hdfs_VERSION=$(hdfs_VERSION)" \
+		-e "opentsdb_VERSION=$(opentsdb_VERSION)" \
+		-e "BUILD_NUMBER=$(_BUILD_NUMBER)" \
+		-e "IMAGE_NUMBER=$(IMAGE_NUMBER)" \
+		-e "MILESTONE=$(MILESTONE)" \
+		-e "RELEASE_PHASE=$(RELEASE_PHASE)" \
 		-w /mnt/pwd \
+		-u builder \
 		$(BUILD_IMAGE) \
-		bash -c '/mnt/pwd/pkg/add_user.sh $(UID) && su serviceduser -c "make \
-			VERSION=$(VERSION) \
-			SHORT_VERSION=$(SHORT_VERSION) \
-			hbase_VERSION=$(hbase_VERSION) \
-			hdfs_VERSION=$(hdfs_VERSION) \
-			opentsdb_VERSION=$(opentsdb_VERSION) \
-			BUILD_NUMBER=$(_BUILD_NUMBER) \
-			IMAGE_NUMBER=$(IMAGE_NUMBER) \
-			MILESTONE=$(MILESTONE) \
-			RELEASE_PHASE=$(RELEASE_PHASE) \
-			svcdefpkg-$*"'
+		make svcdefpkg-$*
 
-clean:
+clean: clean-migrations
+	@rm -f image/Dockerfile
 	@for dir in $(MKDIRS) ;\
 	do \
 		if [ -d $${dir} ];then \
@@ -257,7 +266,7 @@ clean:
 			rm -rf $${dir} ;\
 		fi ;\
 	done
-	cd pkg && make clean
+	@make -C pkg clean
 
 MKDIRS = $(OUTPUT) buildroot buildroot/output $(svcdef_BUILD_DIR)
 $(MKDIRS):
@@ -265,3 +274,26 @@ $(MKDIRS):
 		echo "mkdir -p $@" ;\
 		mkdir -p $@ ;\
 	fi
+
+###############################
+# zenservicemigration package #
+###############################
+
+build-migrations: docker_buildimage $(OUTPUT)
+	$(DOCKER) run \
+		--rm \
+		-v $(PWD):/mnt/pwd \
+		-v $(OUTPUT):/mnt/pwd/output \
+		-e "VERSION=$(VERSION)" \
+		-e "BUILD_NUMBER=$(_BUILD_NUMBER)" \
+		-e "IMAGE_NUMBER=$(IMAGE_NUMBER)" \
+		-e "MILESTONE=$(MILESTONE)" \
+		-e "RELEASE_PHASE=$(RELEASE_PHASE)" \
+		-w /mnt/pwd \
+		-u builder \
+		$(BUILD_IMAGE) \
+		make -C migrations wheel
+	cp migrations/dist/*.whl output/
+
+clean-migrations:
+	@make -C migrations clean

--- a/migrations/makefile
+++ b/migrations/makefile
@@ -1,0 +1,8 @@
+wheel:
+	@python2 setup.py bdist_wheel
+
+develop:
+	@python2 setup.py develop
+
+clean:
+	@rm -rf build dist src/zenservicemigration.egg-info

--- a/migrations/setup.py
+++ b/migrations/setup.py
@@ -1,0 +1,33 @@
+from __future__ import print_function
+
+import os
+import sys
+from setuptools import setup, find_packages
+
+_version = os.environ.get("VERSION")
+if _version is None:
+    print("VERSION environment variable not found", file=sys.stderr)
+    sys.exit(1)
+
+
+setup(
+    name="zenservicemigration",
+    version=_version,
+    description="Zenoss Service Definition Migration Scripts",
+    author="Zenoss, Inc.",
+    url="https://www.zenoss.com",
+    package_dir={"": "src"},
+    packages=find_packages(where="src"),
+    include_package_data=True,
+    package_data={
+        "zenservicemigration": ["migrations/*.py"],
+    },
+    zip_safe=False,
+    install_requires=["servicemigration"],
+    python_requires=">=2.7,<3",
+    entry_points={
+        "console_scripts": [
+            "zensvcmigrate=zenservicemigration.migrate:main",
+        ],
+    },
+)

--- a/migrations/src/zenservicemigration/migrate.py
+++ b/migrations/src/zenservicemigration/migrate.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python2.7
+
+from __future__ import print_function
+
+import argparse
+import imp
+import os
+import pkg_resources
+import sys
+
+from itertools import dropwhile
+
+import Globals  # noqa: F401 because Zenoss
+
+# Import _after_ importing Globals due to Zenoss Product dependencies
+import servicemigration as sm
+sm.require("1.1.15")
+
+
+class Script(object):
+
+    version = None
+    script = None
+
+    def __init__(self, script):
+        self.version = pkg_resources.parse_version(script.version)
+        self.script = script
+        self.__key = (self.version, self.script.__name__)
+
+    def migrate(self, ctx, *args, **kw):
+        return self.script.migrate(ctx, *args, **kw)
+
+    def __lt__(self, other):
+        return self.__key < other.__key
+
+    def __le__(self, other):
+        return self.__key <= other.__key
+
+    def __gt__(self, other):
+        return self.__key > other.__key
+
+    def __ge__(self, other):
+        return self.__key >= other.__key
+
+    def __eq__(self, other):
+        return self.__key == other.__key
+
+    def __ne__(self, other):
+        return self.__key != other.__key
+
+    def __str__(self):
+        return os.path.basename(self.script.__name__)
+
+
+def list_script_files(path):
+    for filename in os.listdir(path):
+        if filename == "__init__.py" or filename[-3:] != ".py":
+            continue
+        yield filename
+
+
+def get_scripts(path):
+    scripts = []
+    for filename in list_script_files(path):
+        filepath = os.path.join(path, filename)
+        script_name = filename[:-3]
+        script = imp.load_source(script_name, filepath)
+        if not (hasattr(script, "version") and hasattr(script, "migrate")):
+            continue
+        scripts.append(Script(script))
+    return scripts
+
+
+def get_service_context():
+    try:
+        return sm.ServiceContext()
+    except sm.ServiceMigrationError as ex:
+        print(
+            "Couldn't generate service context: {}".format(ex),
+            file=sys.stderr,
+        )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run service definition migrations",
+    )
+    parser.add_argument(
+        "--from", required=True, metavar="VERSION", dest="after",
+        help="Run migrations targeted for releases after this version",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    from_version = pkg_resources.parse_version(args.after)
+
+    path = os.path.join(os.path.dirname(__file__), "migrations")
+    scripts = sorted(get_scripts(path))
+
+    for script in dropwhile(lambda s: s.version <= from_version, scripts):
+        ctx = get_service_context()
+        if ctx is None:
+            print("Skipping migration {}.".format(script))
+            continue
+        try:
+            updated = script.migrate(ctx)
+            if updated:
+                ctx.commit()
+                print("Migration {} applied.".format(script))
+            else:
+                print("No changes applied for migration {}.".format(script))
+        except Exception as ex:
+            print(
+                "Migration {0} failed: {1}".format(script, ex),
+                file=sys.stderr,
+            )

--- a/migrations/src/zenservicemigration/migrations/fix_mariadb_configs_for_10_3.py
+++ b/migrations/src/zenservicemigration/migrations/fix_mariadb_configs_for_10_3.py
@@ -1,0 +1,115 @@
+from __future__ import print_function
+
+import re
+
+
+version = "6.5.0"
+
+
+def migrate(ctx, *args, **kw):
+    changed = False
+
+    services = (
+        svc
+        for svc in ctx.services
+        if svc.name in ("mariadb-model", "mariadb-events", "mariadb")
+    )
+    for service in services:
+        updated = False
+
+        if update_config(service.name, service.originalConfigs):
+            updated = True
+
+        if update_config(service.name, service.configFiles):
+            updated = True
+
+        if updated:
+            changed = True
+            print("Updated service '%s'" % (service.name,))
+
+    return changed
+
+
+skip_external_locking = re.compile(
+    r"skip_external_locking\s*\n", re.MULTILINE,
+)
+log_error = re.compile(r"log_error=(\S+)\s*$", re.MULTILINE)
+innodb_additional_mem_pool_size = re.compile(
+    r"innodb_additional_mem_pool_size\s*=.*\n", re.MULTILINE,
+)
+innodb_file_format = re.compile(
+    r"\s*\n"
+    r"#\s*Use the Barracuda file format which enables support for dynamic "
+    r"and\s*\n"
+    r"#\s*compressed row formats.\s*\n"
+    r"innodb_file_format\s*=.*",
+    re.MULTILINE,
+)
+innodb_purge_threads = re.compile(r"innodb_purge_threads\s*=\s*(\d+)\s*")
+purge_threads = 1
+
+
+def update_config(name, configs):
+    config = next(
+        (cfg for cfg in configs if cfg.name.endswith("/my.cnf")),
+        None,
+    )
+    if config is None:
+        print("Service '%s' has no 'my.cnf' config file" % name)
+        return False
+    content = config.content
+    content = reformat_log_error(log_error, content)
+    content = deleteConfig(skip_external_locking, content)
+    content = deleteConfig(innodb_additional_mem_pool_size, content)
+    content = deleteConfig(innodb_file_format, content)
+    content = update_purge_threads(innodb_purge_threads, content)
+    if config.content != content:
+        config.content = content
+        return True
+
+
+def reformat_log_error(matcher, config):
+    result = matcher.search(config)
+    if not result:
+        return config
+    start, end = result.span()
+    captures = result.groups()
+    try:
+        path = captures[0]
+    except IndexError:
+        return config
+    return ''.join((
+        config[:start],
+        "log_error = %s\n" % path,
+        config[end:],
+    ))
+
+
+def update_purge_threads(matcher, config):
+    result = matcher.search(config)
+    if not result:
+        return config
+    start, end = result.span()
+    captures = result.groups()
+    try:
+        count = int(captures[0])
+    except ValueError:
+        count = 0
+    if count < purge_threads:
+        return ''.join((
+            config[:start],
+            "innodb_purge_threads = %s\n\n" % (purge_threads,),
+            config[end:],
+        ))
+    return config
+
+
+def deleteConfig(matcher, config):
+    """Returns a tuple containing the edited config and any data captured
+    by the matcher.
+    """
+    result = matcher.search(config)
+    if not result:
+        return config
+    start, end = result.span()
+    return config[:start] + config[end:]

--- a/pkg/makefile
+++ b/pkg/makefile
@@ -8,13 +8,12 @@ THIS_MAKEFILE := $(notdir $(CURDIR)/$(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_
 # NAME is typically overridden from the toplevel make:
 #    e.g. make -f makefile NAME=zenoss-core
 #
-NAME          = product
-FULL_NAME     = $(NAME)-service
-#FROMVERSION  = 0.3.70
-VERSION       = 5.0.70
-RELEASE_PHASE = # eg, ALPHA1 | BETA1 | CR1 | GA
-MAINTAINER    ="Zenoss CM <cm@zenoss.com>"
-PKGROOT       = pkgroot/$(FULL_NAME)
+NAME           = product
+FULL_NAME      = $(NAME)-service
+VERSION       ?= 5.0.70
+RELEASE_PHASE  = # eg, ALPHA1 | BETA1 | CR1 | GA
+MAINTAINER     ="Zenoss CM <cm@zenoss.com>"
+PKGROOT        = pkgroot/$(FULL_NAME)
 
 # Package versions will follow the following idiom:
 #
@@ -75,7 +74,7 @@ desc:
 
 .PHONY: clean_files
 clean_files:
-	for pkg in *.deb *.rpm serviced;\
+	@for pkg in *.deb *.rpm serviced;\
 	do \
 		if [ -f "$${pkg}" ];then \
 			echo "rm -f $${pkg}" ;\
@@ -92,7 +91,7 @@ clean_files:
 .PHONY: clean_dirs
 clean_dirs = $(PKGROOT) pkgroot templates
 clean_dirs:
-	for dir in $(clean_dirs) ;\
+	@for dir in $(clean_dirs) ;\
 	do \
 		if [ -d "$${dir}" ];then \
 			echo "rm -rf $${dir}" ;\


### PR DESCRIPTION
The 'zenservicemigration' package is designed to run during the upgrade of a Zenoss system without relying on ZODB.

The inaugural migration is to migrate the mariadb services to use the MariaDB 10.3 image.

Fixes ZEN-32769.