### PR TITLE
Set innodb_buffer_pool_instances to 1.

### DIFF
--- a/services/Zenoss.core.full/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.core.full/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
@@ -7,9 +7,10 @@ skip-host-cache
 skip-name-resolve
 log_error = /var/log/mysqld.log
 
-# Buffer pool instances should equal number of cores (subtract 1 for VMs) 
-# TODO: instances should be at least 1GB, so this should be scaled to buffer_pool_size as well
-innodb_buffer_pool_instances = 3
+# Setting innodb_buffer_pool_instances to 1 to avoid issue MDEV-21826.
+# Additionally, this option was removed in MariaDB 10.5.1 because it offers
+# little performance benefits.
+innodb_buffer_pool_instances = 1
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/Zenoss.core/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.core/Infrastructure/mariadb/-CONFIGS-/etc/my.cnf
@@ -8,9 +8,10 @@ skip-host-cache
 skip-name-resolve
 log_error=/var/log/mysqld.log
 
-# Buffer pool instances should equal number of cores (subtract 1 for VMs) 
-# Buffer pool size should be at least 1G per instance per MySQL documentation 
-innodb_buffer_pool_instances = 3 
+# Setting innodb_buffer_pool_instances to 1 to avoid issue MDEV-21826.
+# Additionally, this option was removed in MariaDB 10.5.1 because it offers
+# little performance benefits.
+innodb_buffer_pool_instances = 1
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/Zenoss.resmgr.lite/Infrastructure/mariadb-events/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.resmgr.lite/Infrastructure/mariadb-events/-CONFIGS-/etc/my.cnf
@@ -65,9 +65,10 @@ innodb_purge_threads = 1
 # Introduce operation lag to allow purge operations. (default is 0)
 innodb_max_purge_lag = 0
 
-# Set buffer pool instances (cpu core count for physical machines, subtract one for VMs)
-# TODO: instances should be at least 1GB, so this should be scaled to buffer_pool_size as well
-innodb_buffer_pool_instances = {{.CPUCommitment}}
+# Setting innodb_buffer_pool_instances to 1 to avoid issue MDEV-21826.
+# Additionally, this option was removed in MariaDB 10.5.1 because it offers
+# little performance benefits.
+innodb_buffer_pool_instances = 1
 
 # Increase number of connections + open file handles
 max_connections = 1000

--- a/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.resmgr.lite/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -8,9 +8,10 @@ skip-host-cache
 skip-name-resolve
 log_error=/var/log/mysqld.log
 
-# Buffer pool instances should equal number of cores (subtract 1 for VMs) 
-# Buffer pool size should be at least 1G per instance per MySQL documentation 
-innodb_buffer_pool_instances = 3 
+# Setting innodb_buffer_pool_instances to 1 to avoid issue MDEV-21826.
+# Additionally, this option was removed in MariaDB 10.5.1 because it offers
+# little performance benefits.
+innodb_buffer_pool_instances = 1
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}}  
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be

--- a/services/Zenoss.resmgr/Infrastructure/mariadb-events/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.resmgr/Infrastructure/mariadb-events/-CONFIGS-/etc/my.cnf
@@ -59,9 +59,10 @@ innodb_purge_threads = 1
 # Introduce operation lag to allow purge operations. (default is 0)
 innodb_max_purge_lag = 0
 
-# Set buffer pool instances (cpu core count for physical machines, subtract one for VMs)
-# TODO: instances should be at least 1GB, so this should be scaled to buffer_pool_size as well
-innodb_buffer_pool_instances = {{.CPUCommitment}}
+# Setting innodb_buffer_pool_instances to 1 to avoid issue MDEV-21826.
+# Additionally, this option was removed in MariaDB 10.5.1 because it offers
+# little performance benefits.
+innodb_buffer_pool_instances = 1
 
 # Increase number of connections + open file handles
 max_connections = 1000

--- a/services/Zenoss.resmgr/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
+++ b/services/Zenoss.resmgr/Infrastructure/mariadb-model/-CONFIGS-/etc/my.cnf
@@ -7,9 +7,10 @@ skip-host-cache
 skip-name-resolve
 log_error = /var/log/mysqld.log
 
-# Buffer pool instances should equal number of cores (subtract 1 for VMs) 
-# TODO: instances should be at least 1GB, so this should be scaled to buffer_pool_size as well
-innodb_buffer_pool_instances = 3
+# Setting innodb_buffer_pool_instances to 1 to avoid issue MDEV-21826.
+# Additionally, this option was removed in MariaDB 10.5.1 because it offers
+# little performance benefits.
+innodb_buffer_pool_instances = 1
 innodb_buffer_pool_size = {{percentScale .RAMCommitment 0.8}} 
 
 # TODO: Log file size should be 25% of of buffer pool size, but this cannot be


### PR DESCRIPTION
MariaDB 10.3.22 has a bug that prevents crash recovery when the instance count is greater an 1.

Fixes ZEN-32835.