### PR TITLE
Update relstorage/ZODB cache in zenjobs.

### DIFF
--- a/migrations/src/zenservicemigration/migrations/data/zenjobs-celery3126upgrade_zodb.conf
+++ b/migrations/src/zenservicemigration/migrations/data/zenjobs-celery3126upgrade_zodb.conf
@@ -1,15 +1,24 @@
 %import relstorage
 <zodb>
+  # Target size, in number objects, of each connection's object cache.
+  # Default is 5000.
+  cache-size {{getContext . "global.conf.zodb-cachesize"}}
+
   <relstorage>
     # Comment these out to stop using memcached
-    cache-module-name memcache
-    cache-servers {{getContext . "global.conf.zodb-cacheservers"}}
+    #cache-module-name memcache
+    #cache-servers {{getContext . "global.conf.zodb-cacheservers"}}
 
-    # RelStorage caches pickled objects in memory, similar to a ZEO
-    # cache. This cache is shared between threads. This parameter
-    # configures the approximate maximum amount of memory the cache
-    # should consume, in megabytes.  It defaults to 10.
+    # RelStorage caches pickled objects in memory.
+    # This cache is shared between threads.
+
+    # This option configures the approximate maximum amount of memory the
+    # cache should consume, in megabytes.  It defaults to 10.
     cache-local-mb 512
+
+    # This option configures the maximum size of an object’s pickle (in bytes)
+    # that can qualify for the “local” cache.  The default is 16384 bytes.
+    cache-local-object-max {{getContext . "global.conf.zodb-cache-max-object-size"}}
 
     keep-history false
     <mysql>

--- a/services/Zenoss.cse/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zodb.conf
+++ b/services/Zenoss.cse/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zodb.conf
@@ -1,15 +1,24 @@
 %import relstorage
 <zodb>
+  # Target size, in number objects, of each connection's object cache.
+  # Default is 5000.
+  cache-size {{getContext . "global.conf.zodb-cachesize"}}
+
   <relstorage>
     # Comment these out to stop using memcached
-    cache-module-name memcache
-    cache-servers {{getContext . "global.conf.zodb-cacheservers"}}
+    #cache-module-name memcache
+    #cache-servers {{getContext . "global.conf.zodb-cacheservers"}}
 
-    # RelStorage caches pickled objects in memory, similar to a ZEO
-    # cache. This cache is shared between threads. This parameter
-    # configures the approximate maximum amount of memory the cache
-    # should consume, in megabytes.  It defaults to 10.
+    # RelStorage caches pickled objects in memory.
+    # This cache is shared between threads.
+
+    # This option configures the approximate maximum amount of memory the
+    # cache should consume, in megabytes.  It defaults to 10.
     cache-local-mb 512
+
+    # This option configures the maximum size of an object’s pickle (in bytes)
+    # that can qualify for the “local” cache.  The default is 16384 bytes.
+    cache-local-object-max {{getContext . "global.conf.zodb-cache-max-object-size"}}
 
     keep-history false
     <mysql>


### PR DESCRIPTION
* Turn off remote cache (memcache)
* Specify additional cache configs Zenoss normally uses but were previously left out of zenjobs' relstorage/ZODB configuration.

ZEN-33096.