### PR TITLE
zenjobs' job-expires option should be global.

### DIFF
--- a/migrations/src/zenservicemigration/migrations/data/zenjobs-celery3126upgrade_zenjobs.conf
+++ b/migrations/src/zenservicemigration/migrations/data/zenjobs-celery3126upgrade_zenjobs.conf
@@ -41,10 +41,6 @@
 # The default value is 5.
 #zodb-max-retries 5
 #
-# How long a job will exist before being deleted.
-# The default value is 604800.
-#job-expires 604800
-#
 # The number of seconds a job is allowed to run before being signaled to stop.
 # The default value is 18000.
 #job-soft-time-limit 18000

--- a/services/Zenoss.cse/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
+++ b/services/Zenoss.cse/Zenoss/User Interface/zenjobs/-CONFIGS-/opt/zenoss/etc/zenjobs.conf
@@ -41,10 +41,6 @@
 # The default value is 5.
 #zodb-max-retries 5
 #
-# How long a job will exist before being deleted.
-# The default value is 604800.
-#job-expires 604800
-#
 # The number of seconds a job is allowed to run before being signaled to stop.
 # The default value is 18000.
 #job-soft-time-limit 18000

--- a/services/Zenoss.cse/service.json
+++ b/services/Zenoss.cse/service.json
@@ -49,6 +49,7 @@
         "global.conf.zauth-password": "MY_PASSWORD",
         "global.conf.zauth-username": "zenoss_system",
         "global.conf.zcml-enable-impact-cse": "Feature",
+        "global.conf.zenjobs-job-expires": "604800",
         "global.conf.zep-admin-password": "",
         "global.conf.zep-admin-user": "root",
         "global.conf.zep-db": "zenoss_zep",


### PR DESCRIPTION
Multiple services (Zope, etc) need access to the job-expires option so move it to the global.conf file.

Fixes ZEN-33101.